### PR TITLE
update urls

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -5,20 +5,20 @@
 		(reconfigure_gui), and provides the way to view and edit the parameters
 		that are accessible via dynamic_reconfigure.<br />
 		<br />
-		(12/27/2012) In the future, arbitrary parameters that are not associated 
-		with any nodes (which are not handled by dynamic_reconfigure) might 
+		(12/27/2012) In the future, arbitrary parameters that are not associated
+		with any nodes (which are not handled by dynamic_reconfigure) might
 		become handled.
-		However, currently as the name indicates, this pkg solely is dependent 
-		on dynamic_reconfigure that allows access to only those params latched 
+		However, currently as the name indicates, this pkg solely is dependent
+		on dynamic_reconfigure that allows access to only those params latched
 		to nodes.
 	</description>
 	<maintainer email="logans@cottsay.net">Scott K Logan</maintainer>
 
 	<license>BSD</license>
 
-	<url type="website">http://ros.org/wiki/rqt_reconfigure</url>
-	<url type="repository">https://github.com/ros-visualization/rqt_common_plugins</url>
-	<url type="bugtracker">https://github.com/ros-visualization/rqt_common_plugins/issues</url>
+	<url type="website">http://wiki.ros.org/rqt_reconfigure</url>
+	<url type="repository">https://github.com/ros-visualization/rqt_reconfigure</url>
+	<url type="bugtracker">https://github.com/ros-visualization/rqt_reconfigure/issues</url>
 
 	<author>Isaac Saito</author>
 	<author>Ze'ev Klapow</author>


### PR DESCRIPTION
With the plugin being split out from `rqt_common_plugins` I will do a last release for Lunar (as well as re-release for Kinetic, Jade, and Indigo) in the next days. After that I will stop watching this repo, not look at issues and pull requests, and not perform new releases.

Someone needs to take over the maintenance role which specifically includes doing new releases. @cottsay You are currently listed in the manifest as the maintainer. I am not sure if you want to take this role and fully take over this repository? @mikaelarguedas Since you maintain `dynamic_reconfigure` maybe you want to be associated with this repo?Or anyone else would like to step up (@ablasdel @k-okada @130s since you have contributed to the package in the past)?

Please let me know if you want to be added / removed from the list of maintainers in the manifest. Otherwise I will go ahead and merge this as-is and release the package a last time setting the maintenance status to `unmaintained`.