### PR TITLE
Set minimum width on right pane to avoid overlap

### DIFF
--- a/resource/paramedit_pane.ui
+++ b/resource/paramedit_pane.ui
@@ -12,7 +12,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>0</width>
+    <width>460</width>
     <height>300</height>
    </size>
   </property>


### PR DESCRIPTION
Before this fix, the minimum width of the right pane was 0, which would result in the following at narrow widths:

![before_overlap_fix](https://cloud.githubusercontent.com/assets/6893343/25509522/8ce71f6c-2b6e-11e7-85d0-2cf40e51a399.png)

After this fix, the panel has a minimum width to prevent this behavior (this is the narrowest the panel resizes):

![after_overlap_fix](https://cloud.githubusercontent.com/assets/6893343/25509537/a70c1190-2b6e-11e7-896a-2bb0d987cc6a.png)

