### PR TITLE
enable reconfigure resize for qt5 with version check

### DIFF
--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -39,7 +39,7 @@ import os
 import time
 
 import dynamic_reconfigure as dyn_reconf
-from python_qt_binding import loadUi
+from python_qt_binding import loadUi, QT_BINDING_VERSION
 from python_qt_binding.QtCore import Qt, Signal
 try:
     from python_qt_binding.QtCore import QItemSelectionModel  # Qt 5
@@ -117,7 +117,9 @@ class NodeSelectorWidget(QWidget):
         # isn't available in .ui file.
         # Ref. http://stackoverflow.com/a/6648906/577001
         try:
-            self._node_selector_view.header().setSectionResizeMode(0, QHeaderView.ResizeToContents)  # Qt5
+            # setSectionResizeMode() is known to crash at least until QT 5.5.1
+            if QT_BINDING_VERSION >= "5.7":
+                self._node_selector_view.header().setSectionResizeMode(0, QHeaderView.ResizeToContents)  # Qt5
         except AttributeError:
             self._node_selector_view.header().setResizeMode(0, QHeaderView.ResizeToContents)  # Qt4
 

--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -116,12 +116,11 @@ class NodeSelectorWidget(QWidget):
         # This 1 line is needed to enable horizontal scrollbar. This setting
         # isn't available in .ui file.
         # Ref. http://stackoverflow.com/a/6648906/577001
-        try:
-            # setSectionResizeMode() is known to crash at least until QT 5.5.1
-            if QT_BINDING_VERSION >= "5.7":
-                self._node_selector_view.header().setSectionResizeMode(0, QHeaderView.ResizeToContents)  # Qt5
-        except AttributeError:
+        if QT_BINDING_VERSION[:2] == "4.":
             self._node_selector_view.header().setResizeMode(0, QHeaderView.ResizeToContents)  # Qt4
+        elif QT_BINDING_VERSION >= "5.7":
+            # setSectionResizeMode() is known to crash at least until QT 5.5.1
+            self._node_selector_view.header().setSectionResizeMode(0, QHeaderView.ResizeToContents)  # Qt5
 
         # Setting slot for when user clicks on QTreeView.
         self.selectionModel = self._node_selector_view.selectionModel()

--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -117,12 +117,9 @@ class NodeSelectorWidget(QWidget):
         # isn't available in .ui file.
         # Ref. http://stackoverflow.com/a/6648906/577001
         try:
-            self._node_selector_view.header().setResizeMode(
-                0, QHeaderView.ResizeToContents)  # Qt4
+            self._node_selector_view.header().setSectionResizeMode(0, QHeaderView.ResizeToContents)  # Qt5
         except AttributeError:
-            # TODO QHeaderView.setSectionResizeMode() is currently segfaulting
-            # using Qt 5 with both bindings PyQt as well as PySide
-            pass
+            self._node_selector_view.header().setResizeMode(0, QHeaderView.ResizeToContents)  # Qt4
 
         # Setting slot for when user clicks on QTreeView.
         self.selectionModel = self._node_selector_view.selectionModel()

--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -118,9 +118,10 @@ class NodeSelectorWidget(QWidget):
         # Ref. http://stackoverflow.com/a/6648906/577001
         if QT_BINDING_VERSION[:2] == "4.":
             self._node_selector_view.header().setResizeMode(0, QHeaderView.ResizeToContents)  # Qt4
-        elif QT_BINDING_VERSION >= "5.7":
-            # setSectionResizeMode() is known to crash at least until QT 5.5.1
-            self._node_selector_view.header().setSectionResizeMode(0, QHeaderView.ResizeToContents)  # Qt5
+        else:
+	    if self._node_selector_view.header().length() > 0:
+              # setSectionResizeMode() crases on zero content
+              self._node_selector_view.header().setSectionResizeMode(0, QHeaderView.ResizeToContents)  # Qt5
 
         # Setting slot for when user clicks on QTreeView.
         self.selectionModel = self._node_selector_view.selectionModel()


### PR DESCRIPTION
Attempting to fix issue #5 by reenabling the resize of the first column with a version check. 

Right now it is known to crash on Qt 5.5.1 and known to work with Qt 5.7