### PR TITLE
Added error handling for dynamic_reconfigure exceptions

### DIFF
--- a/src/rqt_reconfigure/dynreconf_client_widget.py
+++ b/src/rqt_reconfigure/dynreconf_client_widget.py
@@ -42,7 +42,8 @@ from .param_editors import EditorWidget
 from .param_groups import GroupWidget, find_cfg
 from .param_updater import ParamUpdater
 
-from dynamic_reconfigure import DynamicReconfigureParameterException
+from dynamic_reconfigure import (DynamicReconfigureParameterException,
+                                 DynamicReconfigureCallbackException)
 from rospy.service import ServiceException
 
 import yaml
@@ -147,6 +148,8 @@ class DynreconfClientWidget(GroupWidget):
         except ServiceException as e:
             rospy.logwarn('Call for reconfiguration wasn\'t successful because: %s', e.message)
         except DynamicReconfigureParameterException as e:
+            rospy.logwarn('Reconfiguration wasn\'t successful because: %s', e.message)
+        except DynamicReconfigureCallbackException as e:
             rospy.logwarn('Reconfiguration wasn\'t successful because: %s', e.message)
 
     def close(self):

--- a/src/rqt_reconfigure/dynreconf_client_widget.py
+++ b/src/rqt_reconfigure/dynreconf_client_widget.py
@@ -42,6 +42,9 @@ from .param_editors import EditorWidget
 from .param_groups import GroupWidget, find_cfg
 from .param_updater import ParamUpdater
 
+from dynamic_reconfigure import DynamicReconfigureParameterException
+from rospy.service import ServiceException
+
 import yaml
 
 
@@ -138,7 +141,13 @@ class DynreconfClientWidget(GroupWidget):
             configuration = {}
             for doc in yaml.load_all(f.read()):
                 configuration.update(doc)
-        self.reconf.update_configuration(configuration)
+
+        try:
+            self.reconf.update_configuration(configuration)
+        except ServiceException as e:
+            rospy.logwarn('Call for reconfiguration wasn\'t successful because: %s', e.message)
+        except DynamicReconfigureParameterException as e:
+            rospy.logwarn('Reconfiguration wasn\'t successful because: %s', e.message)
 
     def close(self):
         self.reconf.close()


### PR DESCRIPTION
When attempting to update the configuration of a node via dynamic_reconfigure two exceptions could be raised and weren't catched.
`dynamic_reconfigure.DynamicReconfigureParameterException: don't know parameter: ....`
and
`rospy.service.ServiceException: service [/node .../set_parameters] unavailable`
The later one is gets raised because dynamic_reconfigure is not catching it itself and reraising its own exception. I will also issue a PR for the reraising at the dynamic_reconfigure project.
Besides the catches for the occurring exceptions I also already added the catch for the exception I expected will be raised once the PR might have been merged in dynamic_reconfigure. 