### PR TITLE
Fixed the bug that truncated text in the qtreeview widget in node_selector.ui

### DIFF
--- a/resource/node_selector.ui
+++ b/resource/node_selector.ui
@@ -92,7 +92,7 @@
       <bool>true</bool>
      </property>
      <attribute name="headerStretchLastSection">
-      <bool>false</bool>
+      <bool>true</bool>
      </attribute>
     </widget>
    </item>


### PR DESCRIPTION
Before the fix
![truncated](https://user-images.githubusercontent.com/3647772/28857485-d9aaa338-7717-11e7-9614-88b2b4ee5f11.png)

After the fix
![fixed](https://user-images.githubusercontent.com/3647772/28857491-e4fc9ac0-7717-11e7-9741-0484e635209a.png)

