### PR TITLE
lazy creating of dynamic_reconfigure client for each node

### DIFF
--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -332,14 +332,6 @@ class NodeSelectorWidget(QWidget):
                                 node_name_grn, TreenodeQstdItem.NODE_FULLPATH)
                 _treenode_names = treenodeitem_toplevel.get_treenode_names()
 
-                try:
-                    treenodeitem_toplevel.connect_param_server()
-                except rospy.exceptions.ROSException as e:
-                    rospy.logerr(e.message)
-                    #Skip item that fails to connect to its node.
-                    continue
-                    #TODO: Needs to show err msg on GUI too.
-
                 # Using OrderedDict here is a workaround for StdItemModel
                 # not returning corresponding item to index.
                 self._nodeitems[node_name_grn] = treenodeitem_toplevel


### PR DESCRIPTION
This fixes #19.

In current implementation, the `rqt_reconfigure` node tries to connect all nodes available when it starts.
If I understand ROS ecosystem correctly, each connection uses one socket, so if there are many nodes running in one ROS master such as PR2 robot, it can use up all available sockets.

In this pull request, I fixed codes not to connect to all nodes on the start of the node and only connect when any node is selected instead.

I'm not sure if there is any side effect on this change, but at least it works on my laptop, so any feedback from community is very welcome!