### PR TITLE
Avoid TypeError due to NoneType comparison

### DIFF
--- a/src/rqt_reconfigure/param_updater.py
+++ b/src/rqt_reconfigure/param_updater.py
@@ -67,7 +67,7 @@ class ParamUpdater(threading.Thread):
         rospy.logdebug(' ParamUpdater started')
 
         while not self._stop_flag:
-            if _timestamp_last_commit >= self._timestamp_last_pending:
+            if self._timestamp_last_pending is None or _timestamp_last_commit >= self._timestamp_last_pending:
                     with self._condition_variable:
                         rospy.logdebug(' ParamUpdater loop 1.1')
                         self._condition_variable.wait()


### PR DESCRIPTION
In python3, comparing None with other types is no longer possible. This leads to a TypeError in https://github.com/ros-visualization/rqt_reconfigure/blob/master/src/rqt_reconfigure/param_updater.py#L70. The python2 behavior can be reproduced by changing the line as suggested in this PR.