### PR TITLE
Fix some linter errors and get tests running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.py[co]
+__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rqt_reconfigure)
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+  roslint)
 catkin_package()
 catkin_python_setup()
 
@@ -13,6 +14,13 @@ install(DIRECTORY resource
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(PROGRAMS scripts/rqt_reconfigure
+install(PROGRAMS scripts/${PROJECT_NAME}
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+roslint_python(test)
+
+if (CATKIN_ENABLE_TESTING)
+  roslint_add_test()
+  catkin_add_nosetests(test)
+endif()

--- a/package.xml
+++ b/package.xml
@@ -1,40 +1,44 @@
+<?xml version="1.0"?>
 <package format="2">
-	<name>rqt_reconfigure</name>
-	<version>0.4.10</version>
-	<description>This rqt plugin succeeds former dynamic_reconfigure's GUI
-		(reconfigure_gui), and provides the way to view and edit the parameters
-		that are accessible via dynamic_reconfigure.<br />
-		<br />
-		(12/27/2012) In the future, arbitrary parameters that are not associated
-		with any nodes (which are not handled by dynamic_reconfigure) might
-		become handled.
-		However, currently as the name indicates, this pkg solely is dependent
-		on dynamic_reconfigure that allows access to only those params latched
-		to nodes.
-	</description>
-	<maintainer email="logans@cottsay.net">Scott K Logan</maintainer>
+  <name>rqt_reconfigure</name>
+  <version>0.4.10</version>
+  <description>This rqt plugin succeeds former dynamic_reconfigure's GUI
+    (reconfigure_gui), and provides the way to view and edit the parameters
+    that are accessible via dynamic_reconfigure.<br/>
+    <br/>
+    (12/27/2012) In the future, arbitrary parameters that are not associated
+    with any nodes (which are not handled by dynamic_reconfigure) might
+    become handled.
+    However, currently as the name indicates, this pkg solely is dependent
+    on dynamic_reconfigure that allows access to only those params latched
+    to nodes.
+  </description>
+  <maintainer email="logans@cottsay.net">Scott K Logan</maintainer>
 
-	<license>BSD</license>
+  <license>BSD</license>
 
-	<url type="website">http://wiki.ros.org/rqt_reconfigure</url>
-	<url type="repository">https://github.com/ros-visualization/rqt_reconfigure</url>
-	<url type="bugtracker">https://github.com/ros-visualization/rqt_reconfigure/issues</url>
+  <url type="website">http://wiki.ros.org/rqt_reconfigure</url>
+  <url type="repository">https://github.com/ros-visualization/rqt_reconfigure</url>
+  <url type="bugtracker">https://github.com/ros-visualization/rqt_reconfigure/issues</url>
 
-	<author>Isaac Saito</author>
-	<author>Ze'ev Klapow</author>
+  <author>Isaac Saito</author>
+  <author>Ze'ev Klapow</author>
 
-	<buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin</buildtool_depend>
 
-	<exec_depend>dynamic_reconfigure</exec_depend>
-	<exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
-	<exec_depend>rospy</exec_depend>
-	<exec_depend>rqt_console</exec_depend>
-	<exec_depend>rqt_gui</exec_depend>
-	<exec_depend>rqt_gui_py</exec_depend>
-	<exec_depend>rqt_py_common</exec_depend>
+  <build_depend>roslint</build_depend>
+  <exec_depend>dynamic_reconfigure</exec_depend>
+  <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rqt_console</exec_depend>
+  <exec_depend>rqt_gui</exec_depend>
+  <exec_depend>rqt_gui_py</exec_depend>
+  <exec_depend>rqt_py_common</exec_depend>
 
-	<export>
-		<architecture_independent/>
-		<rqt_gui plugin="${prefix}/plugin.xml" />
-	</export>
+  <test_depend>rostest</test_depend>
+
+  <export>
+    <architecture_independent/>
+    <rqt_gui plugin="${prefix}/plugin.xml"/>
+  </export>
 </package>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <library path="src">
   <class name="Param" type="rqt_reconfigure.param_plugin.ParamPlugin" base_class_type="rqt_gui_py::Plugin">
     <description>

--- a/resource/text_filter_widget.ui
+++ b/resource/text_filter_widget.ui
@@ -18,15 +18,14 @@
 				<number>0</number>
 			</property>
 			<item>
-				<layout class="QHBoxLayout" name="horizontalLayout_2"
-					stretch="0">
+				<layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0">
 					<item>
-						<widget class="QLineEdit" name="text_edit" />
+						<widget class="QLineEdit" name="text_edit"/>
 					</item>
 				</layout>
 			</item>
 		</layout>
 	</widget>
-	<resources />
-	<connections />
+	<resources/>
+	<connections/>
 </ui>

--- a/src/rqt_reconfigure/text_filter.py
+++ b/src/rqt_reconfigure/text_filter.py
@@ -61,11 +61,11 @@ class TextFilter(MessageFilter):
 
         if (self.is_enabled() and
             self._text != '' and
-            not self._qregexp == None  # If None, init process isn't done yet
+            not self._regexp == None   # If None, init process isn't done yet
                                        # and we can ignore the call to this
                                        # method.
             ):
-            pos_hit = self._qregexp.indexIn(text)
+            pos_hit = self._regexp.indexIn(text)
             if pos_hit >= 0:
                 _hit = True
             else:

--- a/test/test_text_filter.py
+++ b/test/test_text_filter.py
@@ -62,6 +62,3 @@ class MyTest(unittest.TestCase):
         self.assertEqual(result_regex,
                          True  # Both _query_text & filtered_text overlaps.
                          )
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_treenode_qstditem.py
+++ b/test/test_treenode_qstditem.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2012, Willow Garage, Inc.
@@ -49,8 +47,9 @@ class TestTreenodeQstdItem(unittest.TestCase):
 
     def setUp(self):
         unittest.TestCase.setUp(self)
-        #self._item = TreenodeQstdItem(self._nodename_raw, 0) # For unknown reason
-                                                        #this stops operation.
+
+        # For unknown reason this stops operation.
+        # self._item = TreenodeQstdItem(self._nodename_raw, 0)
         self._item = TreenodeQstdItem(self._nodename_raw)
 
     def tearDown(self):
@@ -63,7 +62,3 @@ class TestTreenodeQstdItem(unittest.TestCase):
 
 #    def test_get_node_name(self):
 #        self.assertEqual(self._item.get_widget().show())
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
This change excludes the actual sources from running linters, but gets the infrastructure in place to do so. I'll follow up with a change to bring the sources into conformance.

Again, the motivation is to help align the ROS 1 package with the ROS 2 package to minimize the drift.