### PR TITLE
Re-format license headers to conform to ROS templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 Any contribution that you make to this repository will
-be under the BSD license.
-[license](https://opensource.org/licenses/BSD-3-Clause):
+be under the BSD license 2.0, as dictated by that
+[license](https://opensource.org/licenses/BSD-3-Clause).

--- a/LICENSE
+++ b/LICENSE
@@ -1,25 +1,30 @@
-Copyright (c) 2012, Willow Garage, Inc.
-              2019, Open Source Robotics Foundation, Inc.
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
+Software License Agreement (BSD License 2.0)
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/src/rqt_reconfigure/filter_children_model.py
+++ b/src/rqt_reconfigure/filter_children_model.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/logging.py
+++ b/src/rqt_reconfigure/logging.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2019, Open Source Robotics Foundation, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/param_client_widget.py
+++ b/src/rqt_reconfigure/param_client_widget.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/param_groups.py
+++ b/src/rqt_reconfigure/param_groups.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/param_plugin.py
+++ b/src/rqt_reconfigure/param_plugin.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/param_updater.py
+++ b/src/rqt_reconfigure/param_updater.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/param_widget.py
+++ b/src/rqt_reconfigure/param_widget.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/paramedit_widget.py
+++ b/src/rqt_reconfigure/paramedit_widget.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/text_filter.py
+++ b/src/rqt_reconfigure/text_filter.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -14,7 +16,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #  * Neither the name of Willow Garage, Inc. nor the names of its
-#    contributors may be used to stoporse or promote products derived
+#    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS

--- a/src/rqt_reconfigure/text_filter_widget.py
+++ b/src/rqt_reconfigure/text_filter_widget.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/treenode_item_model.py
+++ b/src/rqt_reconfigure/treenode_item_model.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/treenode_qstditem.py
+++ b/src/rqt_reconfigure/treenode_qstditem.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/rqt_reconfigure/treenode_status.py
+++ b/src/rqt_reconfigure/treenode_status.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/test/test_text_filter.py
+++ b/test/test_text_filter.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/test/test_treenode_qstditem.py
+++ b/test/test_treenode_qstditem.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2012, Willow Garage, Inc.
 # All rights reserved.
 #
+# Software License Agreement (BSD License 2.0)
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:


### PR DESCRIPTION
This change adds a line to the license headers specifying the name of the license that follows. It also re-formats the recently added `LICENSE` and `CONTRIBUTING.md` files to match the templates.