### PR TITLE
Fix ROS 2 package dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -30,10 +30,12 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
   <exec_depend>qt_gui_py_common</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rqt_console</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
-  <exec_depend>rqt_py_console</exec_depend>
   <exec_depend>rqt_py_common</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
References:
* `python3-yaml`: https://github.com/ros-visualization/rqt_reconfigure/blob/116ee13143ea6dc0a9785cd9a70d5600c64191b8/src/rqt_reconfigure/param_client_widget.py#L44
* `rclpy`: https://github.com/ros-visualization/rqt_reconfigure/blob/116ee13143ea6dc0a9785cd9a70d5600c64191b8/src/rqt_reconfigure/logging.py#L35
* `rqt_console`: https://github.com/ros-visualization/rqt_reconfigure/blob/116ee13143ea6dc0a9785cd9a70d5600c64191b8/src/rqt_reconfigure/text_filter.py#L39

I found no references to `rqt_py_console` - I believe it was added by mistake. @gonzodepedro to confirm.