### PR TITLE
Drop explicit catkin_pkg dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,6 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
-  <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>qt_gui_py_common</exec_depend>
   <exec_depend>rclpy</exec_depend>


### PR DESCRIPTION
`catkin_pkg` was previously used in the `setup.py`, but I believe we forgot to remove the dependency when that file got refactored as part of the change to `ament_python`.

@gonzodepedro to confirm.