### PR TITLE
Superficial changes to align ROS 1 and ROS 2 branches

### DIFF
--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -55,8 +55,8 @@ import rosservice
 from rqt_py_common.rqt_ros_graph import RqtRosGraph
 
 from rqt_reconfigure import logging
-from rqt_reconfigure.param_client_widget import ParamClientWidget
 from rqt_reconfigure.filter_children_model import FilterChildrenModel
+from rqt_reconfigure.param_client_widget import ParamClientWidget
 from rqt_reconfigure.treenode_item_model import TreenodeItemModel
 from rqt_reconfigure.treenode_qstditem import TreenodeQstdItem
 
@@ -180,14 +180,13 @@ class NodeSelectorWidget(QWidget):
         self.selectionModel.select(index_current, QItemSelectionModel.Deselect)
 
         try:
-            reconf_widget = self._nodeitems[
+            param_client_widget = self._nodeitems[
                 rosnode_name_selected].get_param_client_widget()
         except ROSException as e:
             raise e
 
         # Signal to notify other pane that also contains node widget.
-        self.sig_node_selected.emit(reconf_widget)
-        # self.sig_node_selected.emit(self._nodeitems[rosnode_name_selected])
+        self.sig_node_selected.emit(param_client_widget)
 
     def _selection_selected(self, index_current, rosnode_name_selected):
         """Intended to be called from _selection_changed_slot."""
@@ -275,8 +274,9 @@ class NodeSelectorWidget(QWidget):
                 self._selection_selected(index_current, rosnode_name_selected)
             except ROSException as e:
                 # TODO: print to sysmsg pane
-                err_msg = e.message + '. Connection to node=' + \
-                    format(rosnode_name_selected) + ' failed'
+                err_msg = 'Connection to node={} failed:\n{}'.format(
+                    rosnode_name_selected, e.message
+                )
                 self._signal_msg.emit(err_msg)
                 logging.error(err_msg)
 
@@ -329,7 +329,9 @@ class NodeSelectorWidget(QWidget):
                 # Instantiate QStandardItem. Inside, dyn_reconf client will
                 # be generated too.
                 treenodeitem_toplevel = TreenodeQstdItem(
-                    node_name_grn, TreenodeQstdItem.NODE_FULLPATH)
+                    node_name_grn,
+                    TreenodeQstdItem.NODE_FULLPATH
+                )
                 _treenode_names = treenodeitem_toplevel.get_treenode_names()
 
                 # Using OrderedDict here is a workaround for StdItemModel

--- a/src/rqt_reconfigure/param_client_widget.py
+++ b/src/rqt_reconfigure/param_client_widget.py
@@ -44,10 +44,10 @@ from rospy.service import ServiceException
 
 import yaml
 
-from . import logging
-from .param_editors import EditorWidget
-from .param_groups import find_cfg, GroupWidget
-from .param_updater import ParamUpdater
+from rqt_reconfigure import logging
+from rqt_reconfigure.param_editors import EditorWidget
+from rqt_reconfigure.param_groups import find_cfg, GroupWidget
+from rqt_reconfigure.param_updater import ParamUpdater
 
 
 class ParamClientWidget(GroupWidget):

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -43,7 +43,7 @@ from python_qt_binding.QtWidgets import QMenu, QWidget
 
 import rospkg
 
-from . import logging
+from rqt_reconfigure import logging
 
 EDITOR_TYPES = {
     'bool': 'BooleanEditor',

--- a/src/rqt_reconfigure/param_groups.py
+++ b/src/rqt_reconfigure/param_groups.py
@@ -40,10 +40,10 @@ from python_qt_binding.QtWidgets import (QFormLayout, QGroupBox,
                                          QHBoxLayout, QLabel, QPushButton,
                                          QTabWidget, QVBoxLayout, QWidget)
 
-from . import logging
+from rqt_reconfigure import logging
 # *Editor classes that are not explicitly used within this .py file still need
 # to be imported. They are invoked implicitly during runtime.
-from .param_editors import (  # noqa: F401
+from rqt_reconfigure.param_editors import (  # noqa: F401
     BooleanEditor, DoubleEditor, EDITOR_TYPES, EditorWidget, EnumEditor,
     IntegerEditor, StringEditor
 )

--- a/src/rqt_reconfigure/param_plugin.py
+++ b/src/rqt_reconfigure/param_plugin.py
@@ -36,7 +36,7 @@ from rqt_gui_py.plugin import Plugin
 
 from rqt_py_common.plugin_container_widget import PluginContainerWidget
 
-from .param_widget import ParamWidget
+from rqt_reconfigure.param_widget import ParamWidget
 
 
 class ParamPlugin(Plugin):

--- a/src/rqt_reconfigure/param_updater.py
+++ b/src/rqt_reconfigure/param_updater.py
@@ -37,7 +37,7 @@ import time
 
 from rospy import ServiceException
 
-from . import logging
+from rqt_reconfigure import logging
 
 
 class ParamUpdater(threading.Thread):

--- a/src/rqt_reconfigure/param_widget.py
+++ b/src/rqt_reconfigure/param_widget.py
@@ -109,22 +109,22 @@ class ParamWidget(QWidget):
         _vlayout_nodesel_side.setSpacing(1)
         _vlayout_nodesel_widget.setLayout(_vlayout_nodesel_side)
 
-        reconf_widget = ParameditWidget(rp)
+        param_edit_widget = ParameditWidget(rp)
 
         self._splitter.insertWidget(0, _vlayout_nodesel_widget)
-        self._splitter.insertWidget(1, reconf_widget)
+        self._splitter.insertWidget(1, param_edit_widget)
         # 1st column, _vlayout_nodesel_widget, to minimize width.
         # 2nd col to keep the possible max width.
         self._splitter.setStretchFactor(0, 0)
         self._splitter.setStretchFactor(1, 1)
 
         # Signal from paramedit widget to node selector widget.
-        reconf_widget.sig_node_disabled_selected.connect(
+        param_edit_widget.sig_node_disabled_selected.connect(
             self._nodesel_widget.node_deselected
         )
         # Pass name of node to editor widget
         self._nodesel_widget.sig_node_selected.connect(
-            reconf_widget.show_reconf
+            param_edit_widget.show_reconf
         )
 
         if not node:

--- a/src/rqt_reconfigure/paramedit_widget.py
+++ b/src/rqt_reconfigure/paramedit_widget.py
@@ -41,7 +41,7 @@ from python_qt_binding.QtWidgets import QVBoxLayout, QWidget, QWidgetItem
 
 from rqt_py_common.layout_util import LayoutUtil
 
-from . import logging
+from rqt_reconfigure import logging
 
 
 class ParameditWidget(QWidget):
@@ -62,7 +62,7 @@ class ParameditWidget(QWidget):
                                'resource', 'paramedit_pane.ui')
         loadUi(ui_file, self, {'ParameditWidget': ParameditWidget})
 
-        self._param_clients = OrderedDict()
+        self._param_client_widgets = OrderedDict()
 
         # Adding the list of Items
         self.vlayout = QVBoxLayout(self.scrollarea_holder_widget)
@@ -90,12 +90,12 @@ class ParameditWidget(QWidget):
         node_grn = param_client_widget.get_node_grn()
         logging.debug('ParameditWidget.show str(node_grn)=%s', str(node_grn))
 
-        if node_grn not in self._param_clients.keys():
+        if node_grn not in self._param_client_widgets.keys():
             # Add param widget if there isn't already one.
 
             # Client gets renewed every time different node_grn was clicked.
 
-            self._param_clients.__setitem__(node_grn, param_client_widget)
+            self._param_client_widgets.__setitem__(node_grn, param_client_widget)
             self.vlayout.addWidget(param_client_widget)
             param_client_widget.sig_node_disabled_selected.connect(
                 self._node_disabled)
@@ -105,18 +105,18 @@ class ParameditWidget(QWidget):
             # LayoutUtil.clear_layout(self.vlayout)
 
             # Re-add the rest of existing items to layout.
-            # for k, v in self._param_clients.items():
+            # for k, v in self._param_client_widgets.items():
             #     logging.info('added to layout k={} v={}'.format(k, v))
             #     self.vlayout.addWidget(v)
 
         # Add color to alternate the rim of the widget.
         LayoutUtil.alternate_color(
-            self._param_clients.values(),
+            self._param_client_widgets.values(),
             [self.palette().window().color().lighter(125),
              self.palette().window().color().darker(125)])
 
     def close(self):
-        for dc in self._param_clients:
+        for dc in self._param_client_widgets:
             # Clear out the old widget
             dc.close()
             dc = None
@@ -136,7 +136,7 @@ class ParameditWidget(QWidget):
 
     def _remove_node(self, node_grn):
         try:
-            i = self._param_clients.keys().index(node_grn)
+            i = list(self._param_client_widgets.keys()).index(node_grn)
         except ValueError:
             # ValueError occurring here means that the specified key is not
             # found, most likely already removed, which is possible in the
@@ -152,10 +152,10 @@ class ParameditWidget(QWidget):
         item = self.vlayout.itemAt(i)
         if isinstance(item, QWidgetItem):
             item.widget().close()
-        w = self._param_clients.pop(node_grn)
+        w = self._param_client_widgets.pop(node_grn)
 
         logging.debug('popped={} Len of left clients={}'.format(
-            w, len(self._param_clients)
+            w, len(self._param_client_widgets)
         ))
 
     def _node_disabled(self, node_grn):

--- a/src/rqt_reconfigure/treenode_item_model.py
+++ b/src/rqt_reconfigure/treenode_item_model.py
@@ -36,7 +36,7 @@ from __future__ import division
 
 from python_qt_binding.QtGui import QStandardItemModel
 
-from . import logging
+from rqt_reconfigure import logging
 
 
 class TreenodeItemModel(QStandardItemModel):

--- a/src/rqt_reconfigure/treenode_qstditem.py
+++ b/src/rqt_reconfigure/treenode_qstditem.py
@@ -46,8 +46,8 @@ from rospy.exceptions import ROSException
 
 from rqt_py_common.data_items import ReadonlyItem
 
-from . import logging
-from .param_client_widget import ParamClientWidget
+from rqt_reconfigure import logging
+from rqt_reconfigure.param_client_widget import ParamClientWidget
 
 
 class ParamserverConnectThread(threading.Thread):
@@ -224,7 +224,7 @@ class TreenodeQstdItem(ReadonlyItem):
             item = ReadonlyItem(param_name)
             item.setBackground(brush)
             param_names_items.append(item)
-        logging.debug('enable_param_items len of paramnames={}'.format(
+        logging.debug('enable_param_items len of param_names={}'.format(
             len(param_names_items)
         ))
         self.appendColumn(param_names_items)
@@ -245,7 +245,7 @@ class TreenodeQstdItem(ReadonlyItem):
 
         self._toplevel_treenode_name = self._list_treenode_names[0]
 
-        logging.debug('paramname={} nodename={} _list_params[-1]={}'.format(
+        logging.debug('param_name={} node_name={} _list_params[-1]={}'.format(
             param_name, self._toplevel_treenode_name,
             self._list_treenode_names[-1]
         ))


### PR DESCRIPTION
The goal of this PR is to take some of the more desirable superficial changes that were made in the ROS 2 package and bring that goodness back to the ROS 1 branch.

This also aligns the two branches more closely.

Mostly:
* reorder imports where appropriate
* rename some variables to be more generic
* use explicit syntax when importing from `rqt_reconfigure` itself