### PR TITLE
Use a consistent formatting method when logging

### DIFF
--- a/src/rqt_reconfigure/param_client_widget.py
+++ b/src/rqt_reconfigure/param_client_widget.py
@@ -63,7 +63,7 @@ class ParamClientWidget(GroupWidget):
         :type node_name: str
         """
         group_desc = reconf.get_group_descriptions()
-        logging.debug('ParamClientWidget.group_desc=%s', group_desc)
+        logging.debug('ParamClientWidget.group_desc={}'.format(group_desc))
         super(ParamClientWidget, self).__init__(ParamUpdater(reconf),
                                                 group_desc, node_name)
 
@@ -108,13 +108,13 @@ class ParamClientWidget(GroupWidget):
             for widget in self.editor_widgets:
                 if isinstance(widget, EditorWidget):
                     if widget.param_name in names:
-                        logging.debug('EDITOR widget.param_name=%s',
-                                      widget.param_name)
+                        logging.debug('EDITOR widget.param_name={}'.format(
+                                      widget.param_name))
                         widget.update_value(config[widget.param_name])
                 elif isinstance(widget, GroupWidget):
                     cfg = find_cfg(config, widget.param_name)
-                    logging.debug('GROUP widget.param_name=%s',
-                                  widget.param_name)
+                    logging.debug('GROUP widget.param_name={}'.format(
+                                  widget.param_name))
                     widget.update_group(cfg)
 
     def _handle_load_clicked(self):
@@ -147,18 +147,18 @@ class ParamClientWidget(GroupWidget):
             self.reconf.update_configuration(configuration)
         except ServiceException as e:
             logging.warn(
-                "Call for reconfiguration wasn't successful because: %s",
-                e.message
+                "Call for reconfiguration wasn't successful"
+                ' because: {}'.format(e.message)
             )
         except DynamicReconfigureParameterException as e:
             logging.warn(
-                "Reconfiguration wasn't successful because: %s",
-                e.message
+                "Reconfiguration wasn't successful"
+                ' because: {}'.format(e.message)
             )
         except DynamicReconfigureCallbackException as e:
             logging.warn(
-                "Reconfiguration wasn't successful because: %s",
-                e.message
+                "Reconfiguration wasn't successful"
+                ' because: {}'.format(e.message)
             )
 
     def close(self):

--- a/src/rqt_reconfigure/param_groups.py
+++ b/src/rqt_reconfigure/param_groups.py
@@ -173,8 +173,8 @@ class GroupWidget(QWidget):
             if param['edit_method']:
                 widget = EnumEditor(self.updater, param)
             elif param['type'] in EDITOR_TYPES:
-                logging.debug('GroupWidget i_debug=%d param type =%s',
-                              i_debug, param['type'])
+                logging.debug('GroupWidget i_debug={} param type ={}'.format(
+                              i_debug, param['type']))
                 editor_type = EDITOR_TYPES[param['type']]
                 widget = eval(editor_type)(self.updater, param)
 
@@ -182,7 +182,7 @@ class GroupWidget(QWidget):
             self._param_names.append(param['name'])
 
             logging.debug(
-                'groups._create_node_widgets num editors=%d', i_debug)
+                'groups._create_node_widgets num editors={}'.format(i_debug))
 
             end = time.time() * 1000
             time_elap = end - begin
@@ -202,13 +202,14 @@ class GroupWidget(QWidget):
                     self.updater, group, self._toplevel_treenode_name)
 
             self.editor_widgets.append(widget)
-            logging.debug('groups._create_node_widgets name=%s', name)
+            logging.debug('groups._create_node_widgets name={}'.format(name))
 
         for i, ed in enumerate(self.editor_widgets):
             ed.display(self.grid)
 
-        logging.debug('GroupWdgt._create_node_widgets len(editor_widgets)=%d',
-                      len(self.editor_widgets))
+        logging.debug('GroupWdgt._create_node_widgets'
+                      ' len(editor_widgets)={}'.format(
+                          len(self.editor_widgets)))
 
     def display(self, grid):
         grid.addRow(self)

--- a/src/rqt_reconfigure/param_widget.py
+++ b/src/rqt_reconfigure/param_widget.py
@@ -145,8 +145,8 @@ class ParamWidget(QWidget):
                 self.sig_selected.emit(rn)
             else:
                 logging.warn(
-                    "Could not find a dynamic reconfigure client named '%s'",
-                    str(rn)
+                    'Could not find a dynamic reconfigure client'
+                    " named '{}'".format(str(rn))
                 )
 
     def shutdown(self):

--- a/src/rqt_reconfigure/paramedit_widget.py
+++ b/src/rqt_reconfigure/paramedit_widget.py
@@ -88,7 +88,8 @@ class ParameditWidget(QWidget):
         @param param_client_widget:
         """
         node_grn = param_client_widget.get_node_grn()
-        logging.debug('ParameditWidget.show str(node_grn)=%s', str(node_grn))
+        logging.debug('ParameditWidget.show'
+                      ' str(node_grn)={}'.format(str(node_grn)))
 
         if node_grn not in self._param_client_widgets.keys():
             # Add param widget if there isn't already one.


### PR DESCRIPTION
This will improve logging function compatibility between ROS 1 and ROS 2.

Right now, some log statements cause an exception in ROS 2 due to the differing signatures. This unification will resolve that.