### PR TITLE
Add sorting for tabs

### DIFF
--- a/src/rqt_reconfigure/param_groups.py
+++ b/src/rqt_reconfigure/param_groups.py
@@ -190,7 +190,7 @@ class GroupWidget(QWidget):
                 editor_type, i_debug, time_elap))
             i_debug += 1
 
-        for name, group in config['groups'].items():
+        for name, group in sorted(config['groups'].items()):
             if group['type'] == 'tab':
                 widget = TabGroup(
                     self, self.updater, group, self._toplevel_treenode_name)


### PR DESCRIPTION
Tabs and other groups seem to be in a (random?) order at the moment. 
This pull request orders them alphabetically.