### PR TITLE
Add escape sequence for the space character

### DIFF
--- a/src/rqt_reconfigure/param_groups.py
+++ b/src/rqt_reconfigure/param_groups.py
@@ -251,7 +251,7 @@ class BoxGroup(GroupWidget):
     def __init__(self, updater, config, nodename):
         super(BoxGroup, self).__init__(updater, config, nodename)
 
-        self.box = QGroupBox(self.param_name)
+        self.box = QGroupBox(self.param_name.replace("\_", " "))
         self.box.setLayout(self.grid)
 
     def display(self, grid):
@@ -296,7 +296,7 @@ class TabGroup(GroupWidget):
         self.wid = QWidget()
         self.wid.setLayout(self.grid)
 
-        parent.tab_bar.addTab(self.wid, self.param_name)
+        parent.tab_bar.addTab(self.wid, self.param_name.replace("\_", " "))
 
     def display(self, grid):
         if not self.parent.tab_bar_shown:
@@ -330,7 +330,7 @@ class ApplyGroup(BoxGroup):
         self.updater = ApplyGroup.ApplyUpdater(updater, self.update_group)
         super(ApplyGroup, self).__init__(self.updater, config, nodename)
 
-        self.button = QPushButton('Apply %s' % self.param_name)
+        self.button = QPushButton('Apply %s' % self.param_name.replace("\_", " "))
         self.button.clicked.connect(self.updater.apply_update)
 
         self.grid.addRow(self.button)


### PR DESCRIPTION
Currently spaces in group names defined in the `.cfg` file get substituted with underscores.
To use spaces in the ui titles of groups, I added the substitution from the escape sequence `\_` to ` `.
The uage of underscores in the title is still possible.