### PR TITLE
Gracefully handle non-ASCII chracter input

### DIFF
--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -195,6 +195,8 @@ class StringEditor(EditorWidget):
         self._update_signal.emit(value)
 
     def edit_finished(self):
+        # Filter non-ASCII characters
+        self._paramval_lineedit.setText(self._paramval_lineedit.text().encode('ascii', 'ignore').decode())
         logging.debug('StringEditor edit_finished val={}'.format(
             self._paramval_lineedit.text()))
         self._update_paramserver(self._paramval_lineedit.text())


### PR DESCRIPTION
Non-ASCII characters (e.g. umlaut äöü) lead to the rqt_reconfigure tool crashing. By filtering non-ASCII characters the editor doesn't crash and there is immediate feedback to the user that those characters don't work here.