### PR TITLE
Update package build to support ROS Noetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rqt_reconfigure)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rqt_reconfigure</name>
   <version>0.5.1</version>
   <description>This rqt plugin succeeds former dynamic_reconfigure's GUI
@@ -25,6 +28,8 @@
   <author>Ze'ev Klapow</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>roslint</build_depend>
   <exec_depend>dynamic_reconfigure</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+    from distutils.core import setup
+except ImportError:
+    from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 try:
-    from distutils.core import setup
-except ImportError:
     from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 


### PR DESCRIPTION
Following the guidelines to migrate packages to [noetic](http://wiki.ros.org/noetic/Migration)

- import setup from setuptools instead of distutils-core

- Bump CMake version to avoid CMP0048 warning
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

Signed-off-by: ahcorde <ahcorde@gmail.com>