### PR TITLE
Handle non-ASCII characters in log messages in Python 2

### DIFF
--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -191,12 +191,13 @@ class StringEditor(EditorWidget):
 
     def update_value(self, value):
         super(StringEditor, self).update_value(value)
-        logging.debug('StringEditor update_value={}'.format(value))
+        logging.debug('StringEditor update_value={}'.format(
+            value.encode(errors='replace').decode()))
         self._update_signal.emit(value)
 
     def edit_finished(self):
         logging.debug('StringEditor edit_finished val={}'.format(
-            self._paramval_lineedit.text()))
+            self._paramval_lineedit.text().encode(errors='replace').decode()))
         self._update_paramserver(self._paramval_lineedit.text())
 
     def _set_to_empty(self):


### PR DESCRIPTION
It seems that `dynamic_reconfigure` can handle non-ASCII characters just fine, but the rospy loggers don't take unicode characters very well when running in python 2. This change re-encodes to the native encoding and replaces troublesome characters with '?' in the log messages.

On Python 3, the unicode characters are printed to the log just fine.

Closes #67 