### PR TITLE
Don't process scroll events unless specifically focused

### DIFF
--- a/resource/editor_enum.ui
+++ b/resource/editor_enum.ui
@@ -34,6 +34,9 @@
      </item>
      <item>
       <widget class="QComboBox" name="_combobox">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
        <property name="minimumSize">
         <size>
          <width>30</width>

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -37,7 +37,7 @@ import math
 import os
 
 from python_qt_binding import loadUi
-from python_qt_binding.QtCore import QLocale, Signal
+from python_qt_binding.QtCore import QEvent, QLocale, Signal
 from python_qt_binding.QtGui import QDoubleValidator, QIntValidator
 from python_qt_binding.QtWidgets import QMenu, QWidget
 
@@ -246,6 +246,14 @@ class IntegerEditor(EditorWidget):
         self.cmenu.addAction(self.tr('Set to Minimum')
                              ).triggered.connect(self._set_to_min)
 
+        # Don't process wheel events when not focused
+        self._slider_horizontal.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel and not obj.hasFocus():
+            return True
+        return super(EditorWidget, self).eventFilter(obj, event)
+
     def _slider_moved(self):
         # This is a "local" edit - only change the text
         self._paramval_lineEdit.setText(str(
@@ -352,6 +360,14 @@ class DoubleEditor(EditorWidget):
         self.cmenu.addAction(self.tr('Set to NaN')
                              ).triggered.connect(self._set_to_nan)
 
+        # Don't process wheel events when not focused
+        self._slider_horizontal.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel and not obj.hasFocus():
+            return True
+        return super(EditorWidget, self).eventFilter(obj, event)
+
     def _slider_moved(self):
         # This is a "local" edit - only change the text
         self._paramval_lineEdit.setText('{0:f}'.format(Decimal(str(
@@ -441,6 +457,14 @@ class EnumEditor(EditorWidget):
 
         # Bind the context menu
         self._combobox.contextMenuEvent = self.contextMenuEvent
+
+        # Don't process wheel events when not focused
+        self._combobox.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel and not obj.hasFocus():
+            return True
+        return super(EditorWidget, self).eventFilter(obj, event)
 
     def selected(self, index):
         self._update_paramserver(self.values[index])

--- a/src/rqt_reconfigure/param_groups.py
+++ b/src/rqt_reconfigure/param_groups.py
@@ -34,7 +34,7 @@
 
 import time
 
-from python_qt_binding.QtCore import QMargins, QSize, Qt, Signal
+from python_qt_binding.QtCore import QEvent, QMargins, QSize, Qt, Signal
 from python_qt_binding.QtGui import QFont, QIcon
 from python_qt_binding.QtWidgets import (QFormLayout, QGroupBox,
                                          QHBoxLayout, QLabel, QPushButton,
@@ -293,10 +293,18 @@ class TabGroup(GroupWidget):
         if not self.parent.tab_bar:
             self.parent.tab_bar = QTabWidget()
 
+            # Don't process wheel events when not focused
+            self.parent.tab_bar.tabBar().installEventFilter(self)
+
         self.wid = QWidget()
         self.wid.setLayout(self.grid)
 
         parent.tab_bar.addTab(self.wid, self.param_name)
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel and not obj.hasFocus():
+            return True
+        return super(GroupWidget, self).eventFilter(obj, event)
 
     def display(self, grid):
         if not self.parent.tab_bar_shown:


### PR DESCRIPTION
It can be really easy to accidentally change these values while scrolling along in the editor. This change makes it necessary to focus (clicking on, tabbing to, etc) a widget before the scroll wheel can change it.

Closes #28 