### PR TITLE
Fix loopback propagation for sub-groups of 'apply' groups

### DIFF
--- a/src/rqt_reconfigure/param_groups.py
+++ b/src/rqt_reconfigure/param_groups.py
@@ -228,7 +228,7 @@ class GroupWidget(QWidget):
                 if widget.param_name in names:
                     widget.update_value(config[widget.param_name])
             elif isinstance(widget, GroupWidget):
-                cfg = find_cfg(config, widget.param_name)
+                cfg = find_cfg(config, widget.param_name) or config
                 widget.update_group(cfg)
 
     def close(self):


### PR DESCRIPTION
Parameter names are unique even across groups, so we can propagate the flattened list of updated parameters without any problems. The updates coming from dynamic_reconfigure have been structured into a tree, so we need to continue to support both cases.

Closes #25