### PR TITLE
Save instance state in rqt settings

### DIFF
--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -153,7 +153,7 @@ class NodeSelectorWidget(QWidget):
                 # Deselect the index.
                 self.selectionModel.select(index, QItemSelectionModel.Deselect)
 
-    def node_selected(self, grn):
+    def node_selected(self, grn, scroll_to=False):
         """
         Select the index that corresponds to the given GRN.
 
@@ -168,6 +168,8 @@ class NodeSelectorWidget(QWidget):
             if grn == grn_from_index:
                 # Select the index.
                 self.selectionModel.select(index, QItemSelectionModel.Select)
+                if scroll_to:
+                    self._node_selector_view.scrollTo(index)
                 break
 
     def _enumerate_indexes(self, parent=QModelIndex()):
@@ -493,3 +495,19 @@ class NodeSelectorWidget(QWidget):
                     None, index_parent.data(Qt.DisplayRole),
                     index_deselected.data(Qt.DisplayRole),
                     curr_qstd_item))
+
+    def save_settings(self, instance_settings):
+        expanded_nodes = []
+        for index in self._enumerate_indexes():
+            if self._node_selector_view.isExpanded(index):
+                grn = RqtRosGraph.get_upper_grn(index, '')
+                if grn:
+                    expanded_nodes.append(grn)
+        instance_settings.set_value('expanded_nodes', expanded_nodes)
+
+    def restore_settings(self, instance_settings):
+        expanded_nodes = instance_settings.value('expanded_nodes', [])
+        if expanded_nodes:
+            for index in self._enumerate_indexes():
+                if RqtRosGraph.get_upper_grn(index, '') in expanded_nodes:
+                    self._node_selector_view.setExpanded(index, True)

--- a/src/rqt_reconfigure/paramedit_widget.py
+++ b/src/rqt_reconfigure/paramedit_widget.py
@@ -124,6 +124,9 @@ class ParameditWidget(QWidget):
 
         self._paramedit_scrollarea.deleteLater()
 
+    def get_active_grns(self):
+        return self._param_client_widgets.keys()
+
     def filter_param(self, filter_key):
         """
         :type filter_key:

--- a/src/rqt_reconfigure/text_filter_widget.py
+++ b/src/rqt_reconfigure/text_filter_widget.py
@@ -85,10 +85,10 @@ class TextFilterWidget(QWidget):
         """
         pass
 
-    def save_settings(self, settings):
-        settings.set_value('text', self._parentfilter._text)
+    def save_settings(self, instance_settings):
+        instance_settings.set_value('text', self._parentfilter._text)
 
-    def restore_settings(self, settings):
-        text = settings.value('text', '')
+    def restore_settings(self, instance_settings):
+        text = instance_settings.value('text', '')
         self.set_text(text)
         self.handle_text_changed()


### PR DESCRIPTION
New settings being saved:
- Current node list filter
- Currently expanded items in the node list
- Currently active editors (order preserved)

To reconcile the existing behavior for opening nodes from the command line with the restoration of previously open nodes, I opted to treat the nodes on the command line as an explicit list rather than an additive one. So the command line list effectively 'overrides' the previous state.

Requires #77