### PR TITLE
Support PEP 338 invocation of rqt_reconfigure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
-            package_name + ' = ' + package_name + '.main:main',
+            package_name + ' = ' + package_name + '.__main__:main',
         ],
     },
 )

--- a/src/rqt_reconfigure/__main__.py
+++ b/src/rqt_reconfigure/__main__.py
@@ -36,10 +36,10 @@ from rqt_gui.main import Main
 from rqt_reconfigure.param_plugin import ParamPlugin
 
 
-def main():
+def main(argv=sys.argv):
     plugin = 'rqt_reconfigure.param_plugin.ParamPlugin'
     main = Main(filename=plugin)
-    sys.exit(main.main(sys.argv,
+    sys.exit(main.main(argv,
                        standalone=plugin,
                        plugin_argument_provider=ParamPlugin.add_arguments))
 


### PR DESCRIPTION
This small change makes it possible to start `rqt_reconfigure` with `python3 -m rqt_reconfigure`.