### PR TITLE
Support PEP 338 invocation of rqt_reconfigure

### DIFF
--- a/scripts/rqt_reconfigure
+++ b/scripts/rqt_reconfigure
@@ -2,9 +2,7 @@
 
 import sys
 
-from rqt_gui.main import Main
-from rqt_reconfigure.param_plugin import ParamPlugin
+from rqt_reconfigure.__main__ import main
 
-plugin = 'rqt_reconfigure.param_plugin.ParamPlugin'
-main = Main(filename=plugin)
-sys.exit(main.main(sys.argv, standalone=plugin, plugin_argument_provider=ParamPlugin.add_arguments))
+
+sys.exit(main(sys.argv))

--- a/src/rqt_reconfigure/__main__.py
+++ b/src/rqt_reconfigure/__main__.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2020, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Software License Agreement (BSD License 2.0)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from rqt_gui.main import Main
+from rqt_reconfigure.param_plugin import ParamPlugin
+
+
+def main(argv=sys.argv):
+    plugin = 'rqt_reconfigure.param_plugin.ParamPlugin'
+    main = Main(filename=plugin)
+    sys.exit(main.main(argv,
+                       standalone=plugin,
+                       plugin_argument_provider=ParamPlugin.add_arguments))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This small change makes it possible to start `rqt_reconfigure` with `python3 -m rqt_reconfigure`.

This is a ROS 1 backport of #85, and makes the ROS 1 and ROS 2 branches more similar.