### PR TITLE
Use safe YAML loader

### DIFF
--- a/src/rqt_reconfigure/param_client_widget.py
+++ b/src/rqt_reconfigure/param_client_widget.py
@@ -183,7 +183,7 @@ class ParamClientWidget(QWidget):
         with open(filename, 'r') as f:
             parameters = [
                 rclpy.parameter.Parameter(name=name, value=value)
-                for doc in yaml.load_all(f.read())
+                for doc in yaml.safe_load_all(f.read())
                 for name, value in doc.items()
             ]
 


### PR DESCRIPTION
This change was made in `master` as part of #74. Unlike in ROS 1, the config structure doesn't need a custom YAML constructor to be loaded with the default YAML safe loader.