### PR TITLE
Save instance state in rqt settings

### DIFF
--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -156,7 +156,7 @@ class NodeSelectorWidget(QWidget):
                 # Deselect the index.
                 self.selectionModel.select(index, QItemSelectionModel.Deselect)
 
-    def node_selected(self, grn):
+    def node_selected(self, grn, scroll_to=False):
         """
         Select the index that corresponds to the given GRN.
 
@@ -171,6 +171,8 @@ class NodeSelectorWidget(QWidget):
             if grn == grn_from_index:
                 # Select the index.
                 self.selectionModel.select(index, QItemSelectionModel.Select)
+                if scroll_to:
+                    self._node_selector_view.scrollTo(index)
                 break
 
     def _enumerate_indexes(self, parent=QModelIndex()):
@@ -495,3 +497,19 @@ class NodeSelectorWidget(QWidget):
                     None, index_parent.data(Qt.DisplayRole),
                     index_deselected.data(Qt.DisplayRole),
                     curr_qstd_item))
+
+    def save_settings(self, instance_settings):
+        expanded_nodes = []
+        for index in self._enumerate_indexes():
+            if self._node_selector_view.isExpanded(index):
+                grn = RqtRosGraph.get_upper_grn(index, '')
+                if grn:
+                    expanded_nodes.append(grn)
+        instance_settings.set_value('expanded_nodes', expanded_nodes)
+
+    def restore_settings(self, instance_settings):
+        expanded_nodes = instance_settings.value('expanded_nodes', [])
+        if expanded_nodes:
+            for index in self._enumerate_indexes():
+                if RqtRosGraph.get_upper_grn(index, '') in expanded_nodes:
+                    self._node_selector_view.setExpanded(index, True)

--- a/src/rqt_reconfigure/param_widget.py
+++ b/src/rqt_reconfigure/param_widget.py
@@ -56,7 +56,7 @@ class ParamWidget(QWidget):
     sig_sysprogress = Signal(str)
 
     # To make selections from CLA
-    sig_selected = Signal(str)
+    sig_selected = Signal(str, bool)
 
     def __init__(self, context, node=None):
         """
@@ -105,22 +105,22 @@ class ParamWidget(QWidget):
         _vlayout_nodesel_side.setSpacing(1)
         _vlayout_nodesel_widget.setLayout(_vlayout_nodesel_side)
 
-        param_edit_widget = ParameditWidget()
+        self._param_edit_widget = ParameditWidget()
 
         self._splitter.insertWidget(0, _vlayout_nodesel_widget)
-        self._splitter.insertWidget(1, param_edit_widget)
+        self._splitter.insertWidget(1, self._param_edit_widget)
         # 1st column, _vlayout_nodesel_widget, to minimize width.
         # 2nd col to keep the possible max width.
         self._splitter.setStretchFactor(0, 0)
         self._splitter.setStretchFactor(1, 1)
 
         # Signal from paramedit widget to node selector widget.
-        param_edit_widget.sig_node_disabled_selected.connect(
+        self._param_edit_widget.sig_node_disabled_selected.connect(
             self._nodesel_widget.node_deselected
         )
         # Pass name of node to editor widget
         self._nodesel_widget.sig_node_selected.connect(
-            param_edit_widget.show
+            self._param_edit_widget.show
         )
 
         if not node:
@@ -134,17 +134,10 @@ class ParamWidget(QWidget):
             self._filter_key_changed
         )
 
-        # Open any clients indicated from command line
+        # Signal from widget to open a new editor widget
         self.sig_selected.connect(self._nodesel_widget.node_selected)
 
-        for grn in context.argv():
-            if grn in self._nodesel_widget.get_nodeitems():
-                self.sig_selected.emit(grn)
-            else:
-                logging.warn(
-                    'Could not find a node'
-                    " named '{}'".format(str(grn))
-                )
+        self._explicit_nodes_to_select = list(context.argv())
 
     def shutdown(self):
         # TODO: Needs implemented. Trigger dynamic_reconfigure to unlatch
@@ -153,12 +146,35 @@ class ParamWidget(QWidget):
 
     def save_settings(self, plugin_settings, instance_settings):
         instance_settings.set_value('splitter', self._splitter.saveState())
+        self.filter_lineedit.save_settings(instance_settings)
+        self._nodesel_widget.save_settings(instance_settings)
+        instance_settings.set_value(
+            'selected_nodes', list(self._param_edit_widget.get_active_grns()))
 
     def restore_settings(self, plugin_settings, instance_settings):
         if instance_settings.contains('splitter'):
             self._splitter.restoreState(instance_settings.value('splitter'))
         else:
             self._splitter.setSizes([100, 100, 200])
+        self.filter_lineedit.restore_settings(instance_settings)
+        self._nodesel_widget.restore_settings(instance_settings)
+
+        # Ignore previously open nodes if we were given an explicit list
+        if self._explicit_nodes_to_select:
+            nodes_to_select = self._explicit_nodes_to_select
+            explicit = True
+        else:
+            nodes_to_select = instance_settings.value('selected_nodes') or []
+            explicit = False
+
+        for rn in nodes_to_select:
+            if rn in self._nodesel_widget.get_nodeitems():
+                self.sig_selected.emit(rn, explicit)
+            elif explicit:
+                logging.warn(
+                    'Could not find a dynamic reconfigure client'
+                    " named '{}'".format(str(rn))
+                )
 
     def get_filter_text(self):
         return self.filter_lineedit.text()

--- a/src/rqt_reconfigure/paramedit_widget.py
+++ b/src/rqt_reconfigure/paramedit_widget.py
@@ -115,6 +115,9 @@ class ParameditWidget(QWidget):
         self._param_client_widgets.clear()
         self._paramedit_scrollarea.deleteLater()
 
+    def get_active_grns(self):
+        return self._param_client_widgets.keys()
+
     def filter_param(self, filter_key):
         # TODO Pick nodes that match filter_key.
         #  TODO For the nodes that are kept in previous step, call ParamClientWidget.filter_param

--- a/src/rqt_reconfigure/text_filter_widget.py
+++ b/src/rqt_reconfigure/text_filter_widget.py
@@ -92,10 +92,10 @@ class TextFilterWidget(QWidget):
         """
         pass
 
-    def save_settings(self, settings):
-        settings.set_value('text', self._parentfilter._text)
+    def save_settings(self, instance_settings):
+        instance_settings.set_value('text', self._parentfilter._text)
 
-    def restore_settings(self, settings):
-        text = settings.value('text', '')
+    def restore_settings(self, instance_settings):
+        text = instance_settings.value('text', '')
         self.set_text(text)
         self.handle_text_changed()


### PR DESCRIPTION
New settings being saved:
- Current node list filter
- Currently expanded items in the node list
- Currently active editors (order preserved)

To reconcile the existing behavior for opening nodes from the command line with the restoration of previously open nodes, I opted to treat the nodes on the command line as an explicit list rather than an additive one. So the command line list effectively 'overrides' the previous state.

Requires #87

This is a direct forward-port of #79