### PR TITLE
Address rqt_reconfigure crashing with IndexError  

### DIFF
--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -321,8 +321,8 @@ class NodeSelectorWidget(QWidget):
             num_nodes = len(nodes)
             elapsedtime_overall = 0.0
             for node_name_grn in nodes:
-                # Skip this grn if we already have it
-                if node_name_grn in self._nodeitems:
+                # Skip this grn if we already have it or if node_name_grn is empty
+                if node_name_grn in self._nodeitems or node_name_grn == '':
                     i_node_curr += 1
                     continue
 


### PR DESCRIPTION
 This fixes rqt_reconfigure crashing with an index error as reported in bug #92 .

In certain cases, the list of nodes names include an empty string as the name of a node (mostly when a node has crashed or segfaulted)  -- looking it up resulted in the index error reported in bug #92  and rqt reconfigure crashing. The solution is just to skip that "node".