### PR TITLE
Use timeouts in service calls to avoid hangs

### DIFF
--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -84,6 +84,10 @@ class NodeSelectorWidget(QWidget):
         _, package_path = get_resource('packages', 'rqt_reconfigure')
         ui_file = os.path.join(package_path, 'share', 'rqt_reconfigure', 'resource',
                                'node_selector.ui')
+
+        # Give ROS a bit of time to discover the nodes before populating the node list. Otherwise,
+        # the user has to immediately click the Refresh button to see all of the nodes
+        time.sleep(2)
         loadUi(ui_file, self)
 
         # List of the available nodes. Since the list should be updated over

--- a/src/rqt_reconfigure/node_selector_widget.py
+++ b/src/rqt_reconfigure/node_selector_widget.py
@@ -84,10 +84,6 @@ class NodeSelectorWidget(QWidget):
         _, package_path = get_resource('packages', 'rqt_reconfigure')
         ui_file = os.path.join(package_path, 'share', 'rqt_reconfigure', 'resource',
                                'node_selector.ui')
-
-        # Give ROS a bit of time to discover the nodes before populating the node list. Otherwise,
-        # the user has to immediately click the Refresh button to see all of the nodes
-        time.sleep(2)
         loadUi(ui_file, self)
 
         # List of the available nodes. Since the list should be updated over

--- a/src/rqt_reconfigure/param_api.py
+++ b/src/rqt_reconfigure/param_api.py
@@ -30,10 +30,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import threading
-
-import rclpy
-
 from rcl_interfaces.msg import Parameter as ParameterMsg
 from rcl_interfaces.msg import ParameterEvent
 from rcl_interfaces.srv import DescribeParameters
@@ -41,6 +37,7 @@ from rcl_interfaces.srv import GetParameters
 from rcl_interfaces.srv import ListParameters
 from rcl_interfaces.srv import SetParameters
 
+import rclpy
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_parameter_events
 

--- a/src/rqt_reconfigure/param_api.py
+++ b/src/rqt_reconfigure/param_api.py
@@ -138,7 +138,7 @@ def create_param_client(node, remote_node_name, param_change_callback=None):
     return ParamClient(node, remote_node_name, param_change_callback)
 
 
-def has_parameters(node, node_name, node_namespace):
+def _has_parameters(node, node_name, node_namespace):
     # Get all of the service provided by a node (node_name)
     for service_name, service_types in node.get_service_names_and_types_by_node(node_name, node_namespace):
         # Make sure the node supports the ListParameters service
@@ -150,7 +150,7 @@ def find_nodes_with_params(node):
     names_and_namespaces = node.get_node_names_and_namespaces()
     node_list = []
     for node_name, node_namespace in names_and_namespaces:
-        if has_parameters(node, node_name, node_namespace):
+        if _has_parameters(node, node_name, node_namespace):
             full_name = node_namespace + ('/' if not node_namespace.endswith('/') else '') + node_name
             node_list.append(full_name)
     return node_list

--- a/src/rqt_reconfigure/param_api.py
+++ b/src/rqt_reconfigure/param_api.py
@@ -130,6 +130,7 @@ class ParamClient(object):
         future = client.call_async(request)
         future.add_done_callback(unblock)
         if not event.wait(self._timeout):
+            future.cancel()
             raise AsyncServiceCallFailed(hint='the target node may not be spinning')
         return future.result()
 

--- a/src/rqt_reconfigure/param_api.py
+++ b/src/rqt_reconfigure/param_api.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import threading
+
 from rcl_interfaces.msg import Parameter as ParameterMsg
 from rcl_interfaces.msg import ParameterEvent
 from rcl_interfaces.srv import DescribeParameters
@@ -41,12 +43,19 @@ from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_parameter_events
 
 
+class AsyncServiceCallFailed(Exception):
+    def __init__(self, message='asynchronous service call failed', hint=''):
+        self.message = message if not hint else message + ': ' + hint
+        super().__init__(self.message)
+
+
 class ParamClient(object):
 
     def __init__(self, node, remote_node_name, param_change_callback=None):
 
         self._node = node
         self._remote_node_name = remote_node_name
+        self._timeout = 0.5
         self._get_params_client = self._node.create_client(
             GetParameters, '{remote_node_name}/get_parameters'.format_map(locals())
         )
@@ -77,13 +86,13 @@ class ParamClient(object):
 
     def list_parameters(self):
         list_params_request = ListParameters.Request()
-        list_params_response = self._list_params_client.call(list_params_request)
+        list_params_response = self._async_call(self._list_params_client, list_params_request)
         return list_params_response.result.names
 
     def get_parameters(self, names):
         get_params_request = GetParameters.Request()
         get_params_request.names = names
-        get_params_response = self._get_params_client.call(get_params_request)
+        get_params_response = self._async_call(self._get_params_client, get_params_request)
         return [
             Parameter.from_parameter_msg(ParameterMsg(name=name, value=value))
             for name, value in zip(names, get_params_response.values)
@@ -92,15 +101,13 @@ class ParamClient(object):
     def describe_parameters(self, names):
         describe_params_request = DescribeParameters.Request()
         describe_params_request.names = names
-        describe_params_response = self._describe_params_client.call(
-            describe_params_request
-        )
+        describe_params_response = self._async_call(self._describe_params_client, describe_params_request)
         return describe_params_response.descriptors
 
     def set_parameters(self, parameters):
         set_params_request = SetParameters.Request()
         set_params_request.parameters = [p.to_parameter_msg() for p in parameters]
-        return self._set_params_client.call(set_params_request)
+        return self._async_call(self._set_params_client, set_params_request)
 
     def close(self):
         self._node.destroy_subscription(self._param_events_subscription)
@@ -109,29 +116,42 @@ class ParamClient(object):
         self._node.destroy_client(self._set_params_client)
         self._node.destroy_client(self._get_params_client)
 
+    def _async_call(self, client, request):
+        if not client.service_is_ready():
+            if not client.wait_for_service(self._timeout):
+                raise AsyncServiceCallFailed(hint='timed out waiting for service')
+
+        # It is possible that a node has the parameter services but is not
+        # spinning. In that is the case, the async client call will time out.
+        event = threading.Event()
+        def unblock(future):
+            nonlocal event
+            event.set()
+        future = client.call_async(request)
+        future.add_done_callback(unblock)
+        if not event.wait(self._timeout):
+            raise AsyncServiceCallFailed(hint='the target node may not be spinning')
+        return future.result()
+
 
 def create_param_client(node, remote_node_name, param_change_callback=None):
     return ParamClient(node, remote_node_name, param_change_callback)
 
 
-def _has_params(node, node_name):
-    client = node.create_client(
-        ListParameters,
-        '{node_name}/list_parameters'.format_map(locals()))
-    if not client.service_is_ready():
-        client.wait_for_service()
-    ret = len(client.call(ListParameters.Request()).result.names) > 0
-    node.destroy_client(client)
-    return ret
-
+def has_parameters(node, node_name, node_namespace):
+    # Get all of the service provided by a node (node_name)
+    for service_name, service_types in node.get_service_names_and_types_by_node(node_name, node_namespace):
+        # Make sure the node supports the ListParameters service
+        if 'rcl_interfaces/srv/ListParameters' in service_types:
+            return True
+    return False
 
 def find_nodes_with_params(node):
-    return list(
-        filter(
-            lambda node_name: _has_params(node, node_name),
-            (
-                ns + ('/' if not ns.endswith('/') else '') + node_name
-                for node_name, ns in node.get_node_names_and_namespaces()
-            )
-        )
-    )
+    names_and_namespaces = node.get_node_names_and_namespaces()
+    node_list = []
+    for node_name, node_namespace in names_and_namespaces:
+        if has_parameters(node, node_name, node_namespace):
+            full_name = node_namespace + ('/' if not node_namespace.endswith('/') else '') + node_name
+            node_list.append(full_name)
+    return node_list
+

--- a/src/rqt_reconfigure/param_client_widget.py
+++ b/src/rqt_reconfigure/param_client_widget.py
@@ -111,11 +111,14 @@ class ParamClientWidget(QWidget):
         verticalLayout.addWidget(widget_nodeheader)
         verticalLayout.addWidget(grid_widget, 1)
         # Again, these UI operation above needs to happen in .ui file.
-        param_names = self._param_client.list_parameters()
-        self.add_editor_widgets(
-            self._param_client.get_parameters(param_names),
-            self._param_client.describe_parameters(param_names)
-        )
+        try:
+            param_names = self._param_client.list_parameters()
+            self.add_editor_widgets(
+                self._param_client.get_parameters(param_names),
+                self._param_client.describe_parameters(param_names)
+            )
+        except Exception as e:
+            logging.warn('Failed to retrieve parameters from node: ' + str(e))
 
         # Save and load buttons
         button_widget = QWidget(self)
@@ -144,10 +147,14 @@ class ParamClientWidget(QWidget):
     ):
         # TODO: Think about replacing callback architecture with signals.
         if new_parameters:
-            new_descriptors = self._param_client.describe_parameters(
-                names=[p.name for p in new_parameters]
-            )
-            self.add_editor_widgets(new_parameters, new_descriptors)
+            try:
+                new_descriptors = self._param_client.describe_parameters(
+                    names=[p.name for p in new_parameters]
+                )
+                self.add_editor_widgets(new_parameters, new_descriptors)
+            except Exception as e:
+                logging.warn('Failed to get information about parameters: ' + str(e))
+
         if changed_parameters:
             self.update_editor_widgets(changed_parameters)
         if deleted_parameters:

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -73,7 +73,10 @@ class EditorWidget(QWidget):
 
     def update_remote(self, value):
         # Update the value on Parameter Server.
-        self._param_client.set_parameters([self.parameter])
+        try:
+            self._param_client.set_parameters([self.parameter])
+        except Exception as e:
+            logging.warn('Failed to set parameters for node: ' + str(e))
 
     def update_local(self, value):
         """


### PR DESCRIPTION
Don't assume that all ROS nodes support the parameter services. Instead explicitly look for the ListParameters service.
    
Also, don't assume that all nodes are spinning. Instead of using synchronous service calls (which don't allow for a timeout and will hang if the node is not spinning to process its messages) using an async call, which returns a future that can be used with rclpy.spin_until_future_complete, which supports a timeout.

Note: Parameters can be dynamically added to a node. So, nodes that support the parameter services but currently don't have any parameters could have parameters in the future (currently, all nodes support at least use_sim_time) . So, the presence of the ListParameters service is used as evidence that a node has/can have parameters (since this is used to populate the list of nodes upon a refresh of the node list). 
    
Fixes #97, fixes #96, fixes #64
    
Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>
