### PR TITLE
Fix a flake8 warning.

### DIFF
--- a/src/rqt_reconfigure/param_api.py
+++ b/src/rqt_reconfigure/param_api.py
@@ -43,6 +43,7 @@ from rclpy.qos import qos_profile_parameter_events
 
 
 class AsyncServiceCallFailed(Exception):
+
     def __init__(self, message='asynchronous service call failed', hint=''):
         self.message = message if not hint else message + ': ' + hint
         super().__init__(self.message)


### PR DESCRIPTION
The warning looks like:

CNL100 Class definition does not have a new line.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>