### PR TITLE
Update param_groups.py

### DIFF
--- a/src/rqt_reconfigure/param_groups.py
+++ b/src/rqt_reconfigure/param_groups.py
@@ -216,21 +216,22 @@ class GroupWidget(QWidget):
         grid.addRow(self)
 
     def update_group(self, config):
-        if 'state' in config:
-            old_state = self.state
-            self.state = config['state']
-            if self.state != old_state:
-                self.sig_node_state_change.emit(self.state)
+        if config:
+            if 'state' in config:
+                old_state = self.state
+                self.state = config['state']
+                if self.state != old_state:
+                    self.sig_node_state_change.emit(self.state)
 
-        names = [name for name in config.keys()]
+            names = [name for name in config.keys()]
 
-        for widget in self.editor_widgets:
-            if isinstance(widget, EditorWidget):
-                if widget.param_name in names:
-                    widget.update_value(config[widget.param_name])
-            elif isinstance(widget, GroupWidget):
-                cfg = find_cfg(config, widget.param_name) or config
-                widget.update_group(cfg)
+            for widget in self.editor_widgets:
+                if isinstance(widget, EditorWidget):
+                    if widget.param_name in names:
+                        widget.update_value(config[widget.param_name])
+                elif isinstance(widget, GroupWidget):
+                    cfg = find_cfg(config, widget.param_name) or config
+                    widget.update_group(cfg)
 
     def close(self):
         for w in self.editor_widgets:

--- a/src/rqt_reconfigure/param_groups.py
+++ b/src/rqt_reconfigure/param_groups.py
@@ -216,22 +216,23 @@ class GroupWidget(QWidget):
         grid.addRow(self)
 
     def update_group(self, config):
-        if config:
-            if 'state' in config:
-                old_state = self.state
-                self.state = config['state']
-                if self.state != old_state:
-                    self.sig_node_state_change.emit(self.state)
+        if not config:
+            return
+        if 'state' in config:
+            old_state = self.state
+            self.state = config['state']
+            if self.state != old_state:
+                self.sig_node_state_change.emit(self.state)
 
-            names = [name for name in config.keys()]
+        names = [name for name in config.keys()]
 
-            for widget in self.editor_widgets:
-                if isinstance(widget, EditorWidget):
-                    if widget.param_name in names:
-                        widget.update_value(config[widget.param_name])
-                elif isinstance(widget, GroupWidget):
-                    cfg = find_cfg(config, widget.param_name) or config
-                    widget.update_group(cfg)
+        for widget in self.editor_widgets:
+            if isinstance(widget, EditorWidget):
+                if widget.param_name in names:
+                    widget.update_value(config[widget.param_name])
+            elif isinstance(widget, GroupWidget):
+                cfg = find_cfg(config, widget.param_name) or config
+                widget.update_group(cfg)
 
     def close(self):
         for w in self.editor_widgets:


### PR DESCRIPTION
Sometimes, config is None, which leads to crash of rqt_reconfigure (impossible to update node list). 
This seems to happen when starting rqt_reconfigure from rqt_gui perspective if .cfg of a node was changed since the .perspective file was saved.

```bash
gus@gus-Latitude-E7450:~/ressac/dropter_ws$ roslaunch ajs_controller GS_ajs_controller.launch 
... logging to /home/gus/.ros/log/63da6ad6-7c21-11eb-98ab-61ba7a381d04/roslaunch-gus-Latitude-E7450-319633.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://gus-Latitude-E7450:35103/

SUMMARY
========

PARAMETERS
 * /rosdistro: noetic
 * /rosversion: 1.15.9

NODES
  /
    rqt (rqt_gui/rqt_gui)

ROS_MASTER_URI=http://localhost:11311

process[rqt-1]: started with pid [319647]
[ INFO] [1614776876.098282277]: Loaded configuration from [file:///home/gus/ressac/ressac_ws/src/ajs_controller/extra/rqt_multiplot_cmd-pwm.xml]
[ INFO] [1614776876.129489212]: Loaded configuration from [file:///home/gus/ressac/ressac_ws/src/ajs_controller/extra/rqt_multiplot_health.xml]
[ INFO] [1614776876.207241394]: Loaded configuration from [file:///home/gus/ressac/ressac_ws/src/ajs_controller/extra/rqt_multiplot_pwm.xml]
[ INFO] [1614776876.258609577]: Loaded configuration from [file:///home/gus/ressac/ressac_ws/src/ajs_controller/extra/rqt_multiplot_head-tracking.xml]
[ INFO] [1614776876.333267639]: Loaded configuration from [file:///home/gus/ressac/ressac_ws/src/ajs_controller/extra/rqt_multiplot_speed-tracking.xml]
[ INFO] [1614776876.385054616]: Loaded configuration from [file:///home/gus/ressac/ressac_ws/src/ajs_controller/extra/rqt_multiplot_state_basic.xml]
[ INFO] [1614776876.408935832]: Loaded configuration from [file:///home/gus/ressac/ressac_ws/src/ajs_controller/extra/rqt_multiplot_motor.xml]
[ INFO] [1614776876.461575977]: Loaded configuration from [file:///home/gus/ressac/ressac_ws/src/ajs_controller/extra/rqt_multiplot_state_vehicle.xml]
[ INFO] [1614776876.478985540]: Loaded configuration from [file:///home/gus/ressac/ressac_ws/src/cpu_monitor/extra/rqt_multiplot_cpu_monitor.xml]
[ERROR] [1614776888.924537]: bad callback: <bound method Client._updates_msg of <dynamic_reconfigure.client.Client object at 0x7f02743601f0>>
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/opt/ros/noetic/lib/python3/dist-packages/dynamic_reconfigure/client.py", line 327, in _updates_msg
    self._config_callback(self.config)
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/param_client_widget.py", line 130, in config_callback
    widget.update_group(cfg)
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/param_groups.py", line 219, in update_group
    if 'state' in config:
TypeError: argument of type 'NoneType' is not iterable

[ERROR] [1614776889.662080]: bad callback: <bound method Client._updates_msg of <dynamic_reconfigure.client.Client object at 0x7f02743601f0>>
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/opt/ros/noetic/lib/python3/dist-packages/dynamic_reconfigure/client.py", line 327, in _updates_msg
    self._config_callback(self.config)
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/param_client_widget.py", line 130, in config_callback
    widget.update_group(cfg)
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/param_groups.py", line 219, in update_group
    if 'state' in config:
TypeError: argument of type 'NoneType' is not iterable

Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/node_selector_widget.py", line 282, in _selection_changed_slot
    self._selection_selected(index_current, rosnode_name_selected)
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/node_selector_widget.py", line 233, in _selection_selected
    item_widget = item_child.get_param_client_widget()
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/treenode_qstditem.py", line 159, in get_param_client_widget
    self._param_client_widget = ParamClientWidget(
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/param_client_widget.py", line 103, in __init__
    self.reconf.config_callback = self.config_callback
  File "/opt/ros/noetic/lib/python3/dist-packages/dynamic_reconfigure/client.py", line 276, in set_config_callback
    self._config_callback(self.config)
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/param_client_widget.py", line 130, in config_callback
    widget.update_group(cfg)
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_reconfigure/param_groups.py", line 219, in update_group
    if 'state' in config:
TypeError: argument of type 'NoneType' is not iterable
```