### PR TITLE
Replace deprecated isAlive with is_alive

### DIFF
--- a/src/rqt_reconfigure/treenode_qstditem.py
+++ b/src/rqt_reconfigure/treenode_qstditem.py
@@ -194,7 +194,7 @@ class TreenodeQstdItem(ReadonlyItem):
 
             if not self._param_client:
                 if self._paramserver_connect_thread:
-                    if self._paramserver_connect_thread.isAlive():
+                    if self._paramserver_connect_thread.is_alive():
                         self._paramserver_connect_thread.join(1)
                 self._paramserver_connect_thread = ParamserverConnectThread(
                     self, self._raw_param_name)
@@ -204,7 +204,7 @@ class TreenodeQstdItem(ReadonlyItem):
         with self._lock:
             if self._paramserver_connect_thread:
                 # Try to stop the thread
-                if self._paramserver_connect_thread.isAlive():
+                if self._paramserver_connect_thread.is_alive():
                     self._paramserver_connect_thread.join(1)
                 del self._paramserver_connect_thread
                 self._paramserver_connect_thread = None


### PR DESCRIPTION
`Thread.isAlive()` is deprecated and was removed in Python 3.9. `Thread.is_alive()` should be used instead. This change is backwards compatible (the `is_alive` spelling was added in Python 2.6).
See also https://github.com/ros/ros_comm/pull/2092.