### PR TITLE
Fixed executor conflict

### DIFF
--- a/src/rqt_reconfigure/param_api.py
+++ b/src/rqt_reconfigure/param_api.py
@@ -38,6 +38,7 @@ from rcl_interfaces.srv import SetParameters
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_parameter_events
 
+
 class AsyncServiceCallFailed(Exception):
 
     def __init__(self, message='asynchronous service call failed', hint=''):


### PR DESCRIPTION
Rqt spawns a multi threaded executor, and provides all open plugins in a single node which is spun inside it. But in the `rqt_reconfigure` plugin when calling service, there was added waiting for the end of the call with `spin_until_future_complete`.  This method was giving the control of the rqt to the default rclpy executor.
This issue caused problems like:
- not updating parameters values in rqt_reconfigure to values set from the outside of the rqt
- blocking working of rqt_plot

To fix this issue it's enough to wait for the service request without the `spin_until_future_complete` method. One solution is to use python events and `add_done_callback` method from the future object returned by `call_async` method. The waiting is done with event `wait` function and provided timeout, and can be interrupted by setting the event flag in the callback specified in the `add_done_callback`.