### PR TITLE
Explicitly add a pytest test dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <architecture_independent/>


### PR DESCRIPTION
Since it depends on it to run the tests, explicitly add it here.