### PR TITLE
If updating remote fails, reflect the failure locally

### DIFF
--- a/src/rqt_reconfigure/param_api.py
+++ b/src/rqt_reconfigure/param_api.py
@@ -130,7 +130,7 @@ class ParamClient(object):
         if result is None:
             raise AsyncServiceCallFailed(hint='the target node may not be spinning')
 
-        return future.result()
+        return result
 
 
 def create_param_client(node, remote_node_name, param_change_callback=None):

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -71,9 +71,16 @@ class EditorWidget(QWidget):
     def update_remote(self, value):
         # Update the value on Parameter Server.
         try:
-            self._param_client.set_parameters([self.parameter])
+            result = self._param_client.set_parameters([self.parameter])
+            for res in result.results:
+                if not res.successful:
+                    logging.warn('Failed to set parameters for node: ' + res.reason)
+                    return False
         except Exception as e:
             logging.warn('Failed to set parameters for node: ' + str(e))
+            return False
+        return True
+
 
     def update_local(self, value):
         """
@@ -95,7 +102,8 @@ class EditorWidget(QWidget):
         old_value = self.parameter.value
         self.update_local(value)
         if self.parameter.value != old_value:
-            self.update_remote(value)
+            if not self.update_remote(value):
+                self.update_local(old_value)
 
     def display(self, grid):
         """

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -81,7 +81,6 @@ class EditorWidget(QWidget):
             return False
         return True
 
-
     def update_local(self, value):
         """
         To be implemented in subclass, but still used.


### PR DESCRIPTION
If the remote returns a failure to update the value, the UI reverts back to the old value.

This should resolve #109.

I have not contributed a lot, so if there is anything that needs changed please let me know.

Also, I don't program in python often, so if there is a better way to structure the code I am happy to change that as well!