### PR TITLE
modify layout of number editor

### DIFF
--- a/resource/editor_number.ui
+++ b/resource/editor_number.ui
@@ -24,11 +24,27 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="_layout_h" stretch="0,0,1,0,0">
+    <layout class="QHBoxLayout" name="_layout_h" stretch="0,0,0,1,0">
      <item>
       <widget class="QLabel" name="_paramname_label">
        <property name="text">
         <string>param_name</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="_paramval_lineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>20</height>
+        </size>
        </property>
       </widget>
      </item>
@@ -80,22 +96,6 @@
        </property>
        <property name="text">
         <string>max</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="_paramval_lineEdit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>75</width>
-         <height>20</height>
-        </size>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Hello, Recently one of my colleagues said that it would be more convenient if edit box was closer to parameter name (we are about self-drving softeare, so dynamic parameter involved can be a little more), I am not familiar with qt, so if in maintainers' view, the pr is inappropriate, jsut ignore it.