### PR TITLE
Implemented drop down list for integer parameters with additional constraints. (#150)

### DIFF
--- a/resource/editor_drop_down_list.ui
+++ b/resource/editor_drop_down_list.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>_widget_top</class>
+ <widget class="QWidget" name="_widget_top">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>393</width>
+    <height>50</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>300</width>
+    <height>20</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>param drop down list</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="margin">
+     <number>0</number>
+    </property>
+    <item>
+     <layout class="QHBoxLayout" name="_layout_h" stretch="0,0,1,0,0">
+      <item>
+       <widget class="QLabel" name="_paramname_label">
+        <property name="text">
+         <string>param_name</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="_paramval_drop_down_list"/>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+      </item>
+     </layout>
+    </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     data_files=[
         ('share/' + package_name + '/resource', [
             'resource/editor_bool.ui',
+            'resource/editor_drop_down_list.ui',
             'resource/editor_enum.ui',
             'resource/editor_number.ui',
             'resource/editor_string.ui',

--- a/src/rqt_reconfigure/param_client_widget.py
+++ b/src/rqt_reconfigure/param_client_widget.py
@@ -245,10 +245,18 @@ class ParamClientWidget(QWidget):
         for parameter, descriptor in zip(parameters, descriptors):
             if Parameter.Type(descriptor.type) not in EDITOR_TYPES:
                 continue
+
+            if len(descriptor.additional_constraints) > 0 and descriptor.additional_constraints[0] == "\n":
+                editor_widget = EDITOR_TYPES["DROP_DOWN_LIST"](
+                    self._param_client, parameter, descriptor
+                )
+
+            else:
+                editor_widget = EDITOR_TYPES[parameter.type_](
+                    self._param_client, parameter, descriptor
+                )
+
             logging.debug('Adding editor widget for {}'.format(parameter.name))
-            editor_widget = EDITOR_TYPES[Parameter.Type(descriptor.type)](
-                self._param_client, parameter, descriptor
-            )
             self._editor_widgets[parameter.name] = editor_widget
             editor_widget.display(self.grid)
 

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -150,6 +150,39 @@ class BooleanEditor(EditorWidget):
         self._update_signal.emit(value)
 
 
+class DropDownListEditor(EditorWidget):
+    _update_signal = Signal(int)
+
+    def __init__(self, *args, **kwargs):
+        super(DropDownListEditor, self).__init__(*args, **kwargs)
+        ui_ddl = os.path.join(
+            package_path, 'share', 'rqt_reconfigure', 'resource',
+            'editor_drop_down_list.ui'
+        )
+        loadUi(ui_ddl, self)
+
+        self.contraints = self.descriptor.additional_constraints.split("\n")[1:]
+        self.drop_down_items = []
+
+        for item in self.contraints:
+            t = item.split(",")
+            self.drop_down_items.append(t[1])
+
+        self._paramval_drop_down_list.addItems(self.drop_down_items)
+        self._paramval_drop_down_list.setCurrentIndex(self.parameter.value)
+
+        self._update_signal.connect(self._paramval_drop_down_list.setCurrentIndex)
+
+        self._paramval_drop_down_list.currentIndexChanged.connect(self.index_changed)
+
+    def index_changed(self, index):
+        self.update(int(index))
+
+    def update_local(self, value):
+        super(DropDownListEditor, self).update_local(value)
+        self._update_signal.emit(value)
+
+
 class StringEditor(EditorWidget):
     _update_signal = Signal(str)
 
@@ -310,7 +343,7 @@ class DoubleEditor(EditorWidget):
         )
         loadUi(ui_num, self)
 
-        if len(self.descriptor.floating_point_range) > 0:
+        if(len(self.descriptor.floating_point_range) > 0):
             # Handle unbounded doubles nicely
             self._min = float(self.descriptor.floating_point_range[0].from_value)
             self._min_val_label.setText(str(self._min))
@@ -514,9 +547,5 @@ EDITOR_TYPES = {
     Parameter.Type.INTEGER: IntegerEditor,
     Parameter.Type.DOUBLE: DoubleEditor,
     Parameter.Type.STRING: StringEditor,
-    Parameter.Type.BOOL_ARRAY: ArrayEditor,
-    Parameter.Type.BYTE_ARRAY: ArrayEditor,
-    Parameter.Type.INTEGER_ARRAY: ArrayEditor,
-    Parameter.Type.DOUBLE_ARRAY: ArrayEditor,
-    Parameter.Type.STRING_ARRAY: ArrayEditor,
+    "DROP_DOWN_LIST": DropDownListEditor,
 }


### PR DESCRIPTION
[Issue #150](https://github.com/ros-visualization/rqt_reconfigure/issues/150) is resolved.

#### Changes Made  
  - Added **`DropDownListEditor`** class in params_editor script which parses the `additional_constraints` as key-value pairs in CSV format and fills the drop-down list, while passing the corresponding integer value (keys) in parameter updates.   
 
- Introduced key-value pair **{`"DROP_DOWN_LIST"`: `DropDownListEditor`}** in **`EDITOR_TYPES`**  

- Updated **`add_editor_widgets`** function to check if an integer parameter's descriptor has an additional_constraints and assign **`DropDownListEditor`** instead of the default integer editor if it does.

- added a new Qt Widget **`editor_drop_down_list.ui`** which uses QComboBox to implement drop down list feature.

#### This is How it looks
![Screenshot from 2025-03-31 10-40-14](https://github.com/user-attachments/assets/39667692-f1b0-44e2-8512-280ac428478c)
![Screenshot from 2025-03-31 10-42-52](https://github.com/user-attachments/assets/9d22a6a6-0fdd-4683-984d-5ba0d0b90cf4)
![Screenshot from 2025-03-31 10-39-42](https://github.com/user-attachments/assets/8b506fe8-b194-4aea-b4fc-6a9e03c03a98)

