### PR TITLE
fix setuptools deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -42,7 +41,9 @@ setup(
         'that are accessible via dynamic_reconfigure.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+    'test': [
+            'pytest',
+        ],
     entry_points={
         'console_scripts': [
             package_name + ' = ' + package_name + '.__main__:main',

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,11 @@ setup(
         'that are accessible via dynamic_reconfigure.'
     ),
     license='BSD',
-    'test': [
+    extras_require={
+        'test': [
             'pytest',
         ],
+    },
     entry_points={
         'console_scripts': [
             package_name + ' = ' + package_name + '.__main__:main',


### PR DESCRIPTION
FIX:

#UserWarning: Unknown distribution option: 'tests_require'

and

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!