### PR TITLE
Scale IntegerEditor if range exceeds int32

### DIFF
--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -199,7 +199,6 @@ class StringEditor(EditorWidget):
 
 
 class IntegerEditor(EditorWidget):
-    _update_signal = Signal(int)
 
     def __init__(self, *args, **kwargs):
         super(IntegerEditor, self).__init__(*args, **kwargs)
@@ -215,14 +214,24 @@ class IntegerEditor(EditorWidget):
             self._min_val_label.setText(str(self._min))
             self._max_val_label.setText(str(self._max))
 
-            self._step = int(self.descriptor.integer_range[0].step)
-            self._slider_horizontal.setSingleStep(self._step)
-            self._slider_horizontal.setTickInterval(self._step)
-            self._slider_horizontal.setPageStep(self._step)
-            self._slider_horizontal.setRange(self._min, self._max)
+            if self._max > 2**31-1 or self._min < -2**31:
+                self.scale = (2**31-1) / (self._max - self._min)
+                logging.warn(
+                    f'The range of this parameter is too large for the slider to handle. Scaling down to fit within 32 bits with factor {self.scale}.')
+            else:
+                self.scale = 1
+                # TODO: Fix that the naming of _paramval_lineEdit instance is not
+                #       consistent among Editor's subclasses.
+                self._paramval_lineEdit.setValidator(QIntValidator(self._min,
+                                                    self._max, self))
 
-            self._slider_horizontal.setValue(int(self.parameter.value))
-            self._slider_horizontal.setValue(int(self.parameter.value))
+            self._step = int(self.descriptor.integer_range[0].step)
+            self._slider_horizontal.setSingleStep(self._get_value_slider(self._step))
+            self._slider_horizontal.setTickInterval(self._get_value_slider(self._step))
+            self._slider_horizontal.setPageStep(self._get_value_slider(self._step))
+            self._slider_horizontal.setRange(self._get_value_slider(self._min), self._get_value_slider(self._max))
+
+            self._slider_horizontal.setValue(self._get_value_slider(int(self.parameter.value)))
 
             # Make slider update text (locally)
             self._slider_horizontal.sliderMoved.connect(self._slider_moved)
@@ -237,25 +246,19 @@ class IntegerEditor(EditorWidget):
                                  ).triggered.connect(self._set_to_max)
             self.cmenu.addAction(self.tr('Set to Minimum')
                                  ).triggered.connect(self._set_to_min)
-
-            # TODO: Fix that the naming of _paramval_lineEdit instance is not
-            #       consistent among Editor's subclasses.
-            self._paramval_lineEdit.setValidator(QIntValidator(self._min,
-                                                 self._max, self))
+            
         else:
             self._paramval_lineEdit.setValidator(QIntValidator())
             self._min_val_label.setVisible(False)
             self._max_val_label.setVisible(False)
             self._slider_horizontal.setVisible(False)
+            self.scale = 0
 
         # Make keyboard input change slider position and update param server
         self._paramval_lineEdit.editingFinished.connect(self._text_changed)
 
         # Initialize to default
         self._paramval_lineEdit.setText(str(self.parameter.value))
-
-        # Make the param server update selection
-        self._update_signal.connect(self._update_gui)
 
         if self.descriptor.read_only:
             self._paramval_lineEdit.setEnabled(False)
@@ -265,36 +268,48 @@ class IntegerEditor(EditorWidget):
         # Don't process wheel events when not focused
         self._slider_horizontal.installEventFilter(self)
 
+    def _get_value_slider(self, value):
+        return int(round((value) * self.scale))
+
+    def _get_value_textfield(self):
+        return self._slider_horizontal.sliderPosition() / self.scale if self.scale else 0
+    
     def eventFilter(self, obj, event):
         if event.type() == QEvent.Wheel and not obj.hasFocus():
             return True
         return super(EditorWidget, self).eventFilter(obj, event)
+    
+    def _clamp_int(self, value):
+        return max(-2**31, min(2**31 - 1, value))
 
     def _slider_moved(self):
         # This is a "local" edit - only change the text
         self._paramval_lineEdit.setText(str(
-            self._slider_horizontal.sliderPosition()))
+            self._get_value_textfield()))
 
     def _text_changed(self):
         # This is a final change - update param server
         # No need to update slider... update() will
+        logging.debug('_text_changed called with text: {}'.format(self._paramval_lineEdit.text()))
         self.update(int(self._paramval_lineEdit.text()))
 
     def _slider_changed(self):
         # This is a final change - update param server
         # No need to update text... update() will
-        self.update(self._slider_horizontal.value())
+        logging.debug('_slider_changed called with value: {}'.format(self._get_value_textfield()))
+        self.update(int(self._get_value_textfield()))
 
     def update_local(self, value):
+        logging.debug('update_local called with value: {}'.format(value))
         super(IntegerEditor, self).update_local(value)
         self._update_gui(int(value))
-        self._update_signal.emit(int(value))
 
     def _update_gui(self, value):
+        logging.debug('_update_gui called with value: {}'.format(value))
         # Block all signals so we don't loop
         self._slider_horizontal.blockSignals(True)
         # Update the slider value
-        self._slider_horizontal.setValue(value)
+        self._slider_horizontal.setValue(self._get_value_slider(value))
         # Make the text match
         self._paramval_lineEdit.setText(str(value))
         self._slider_horizontal.blockSignals(False)

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -217,19 +217,22 @@ class IntegerEditor(EditorWidget):
             if self._max > 2**31-1 or self._min < -2**31:
                 self.scale = (2**31-1) / (self._max - self._min)
                 logging.warn(
-                    f'The range of this parameter ({self._min} to {self._max}) is too large for the slider to handle. Scaling down to fit within 32 bits with factor {self.scale}.')
+                    f'The range of this parameter ({self._min} to {self._max}) is too large '
+                    f'for the slider to handle. '
+                    f'Scaling down to fit within 32 bits with factor {self.scale}.'
+                )
             else:
                 self.scale = 1
                 # TODO: Fix that the naming of _paramval_lineEdit instance is not
                 #       consistent among Editor's subclasses.
-                self._paramval_lineEdit.setValidator(QIntValidator(self._min,
-                                                    self._max, self))
+                self._paramval_lineEdit.setValidator(QIntValidator(self._min, self._max, self))
 
             self._step = int(self.descriptor.integer_range[0].step)
             self._slider_horizontal.setSingleStep(self._get_value_slider(self._step))
             self._slider_horizontal.setTickInterval(self._get_value_slider(self._step))
             self._slider_horizontal.setPageStep(self._get_value_slider(self._step))
-            self._slider_horizontal.setRange(self._get_value_slider(self._min), self._get_value_slider(self._max))
+            self._slider_horizontal.setRange(self._get_value_slider(self._min),
+                                             self._get_value_slider(self._max))
 
             self._slider_horizontal.setValue(self._get_value_slider(int(self.parameter.value)))
 
@@ -246,7 +249,7 @@ class IntegerEditor(EditorWidget):
                                  ).triggered.connect(self._set_to_max)
             self.cmenu.addAction(self.tr('Set to Minimum')
                                  ).triggered.connect(self._set_to_min)
-            
+
         else:
             self._paramval_lineEdit.setValidator(QIntValidator())
             self._min_val_label.setVisible(False)
@@ -273,12 +276,12 @@ class IntegerEditor(EditorWidget):
 
     def _get_value_textfield(self):
         return self._slider_horizontal.sliderPosition() / self.scale if self.scale else 0
-    
+
     def eventFilter(self, obj, event):
         if event.type() == QEvent.Wheel and not obj.hasFocus():
             return True
         return super(EditorWidget, self).eventFilter(obj, event)
-    
+
     def _clamp_int(self, value):
         return max(-2**31, min(2**31 - 1, value))
 

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -217,7 +217,7 @@ class IntegerEditor(EditorWidget):
             if self._max > 2**31-1 or self._min < -2**31:
                 self.scale = (2**31-1) / (self._max - self._min)
                 logging.warn(
-                    f'The range of this parameter is too large for the slider to handle. Scaling down to fit within 32 bits with factor {self.scale}.')
+                    f'The range of this parameter ({self._min} to {self._max}) is too large for the slider to handle. Scaling down to fit within 32 bits with factor {self.scale}.')
             else:
                 self.scale = 1
                 # TODO: Fix that the naming of _paramval_lineEdit instance is not


### PR DESCRIPTION
With generate_parameter_library it is common to use validators like gt or lt_eq. It then sets the parameter description to the respective limits, and when a limit is not specified it is set to `std::numeric_limits<int64_t>::max()` or `::lowest()`.
Correct me if I'm wrong, but integer ROS parameters are [64bit integers](https://design.ros2.org/articles/ros_parameters.html)? Qt sliders (hence rqt_reconfigure) do only support 32bit integers.

This results in warnings (btw: without any hint which parameter is causing troubles) and it stops adding parameters to the UI
```
[WARN] [1773491671.480933884] [rqt_reconfigure]: Failed to retrieve parameters from node /admittance_controller: argument 2 overflowed: value must be in the range -2147483648 to 2147483647
[WARN] [1773491671.994429378] [rqt_reconfigure]: Failed to retrieve parameters from node: argument 2 overflowed: value must be in the range -2147483648 to 2147483647
```

I changed the logic to do scaling to 32bit, similar to double sliders.


To reproduce
```
git clone https://github.com/PickNikRobotics/generate_parameter_library.git
colcon build --packages-up-to generate_parameter_library_example
ros2 run generate_parameter_library_example test_node --ros-args --params-file src/generate_parameter_library/example/config/implementation.yaml
```

and selecting admittance_controller node in rqt_reconfigure. Parameters like `lt_eq_fifteen` and `gt_fifteen` are causing troubles.