### PR TITLE
Harden behavior if double value or limit is Infinity

### DIFF
--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -423,7 +423,7 @@ class DoubleEditor(EditorWidget):
         if math.isfinite(value):
             return int(round((self._func(value)) * self.scale))
         if math.isinf(value):
-            return int(round((self._func(math.copysign(100, value)))))        
+            return int(round((self._func(math.copysign(100, value)))))
         # nan
         return 0
 

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -33,6 +33,7 @@ from decimal import Decimal
 import json
 import math
 import os
+import sys
 
 from ament_index_python import get_resource
 
@@ -316,7 +317,6 @@ class DoubleEditor(EditorWidget):
             'editor_number.ui'
         )
         loadUi(ui_num, self)
-
         if len(self.descriptor.floating_point_range) > 0:
             # Handle unbounded doubles nicely
             self._min = float(self.descriptor.floating_point_range[0].from_value)
@@ -328,9 +328,12 @@ class DoubleEditor(EditorWidget):
             self._func = lambda x: x
             self._ifunc = self._func
 
-            # If we have no range, disable the slider
+            # If we have no range, slider is disabled automatically
             self.scale = (self._func(self._max) - self._func(self._min))
-            self.scale = 100 / self.scale
+            if math.isfinite(self.scale):
+                self.scale = 100 / self.scale
+            else:
+                self.scale = 100 / (sys.float_info.max - sys.float_info.min)
 
             # config step
             self._step = float(self.descriptor.floating_point_range[0].step)
@@ -416,7 +419,13 @@ class DoubleEditor(EditorWidget):
         ) if self.scale else 0
 
     def _get_value_slider(self, value):
-        return int(round((self._func(value)) * self.scale))
+
+        if math.isfinite(value):
+            return int(round((self._func(value)) * self.scale))
+        if math.isinf(value):
+            return int(round((self._func(math.copysign(100, value)))))        
+        # nan
+        return 0
 
     def update_local(self, value):
         super(DoubleEditor, self).update_local(value)


### PR DESCRIPTION
If a parameter of type double has an infinite value or limit, rqt_reconfigure fails in displaying the variables with

```
[WARN] [1773494158.221154515] [rqt_reconfigure]: Failed to retrieve parameters from node /admittance_controller: cannot convert float NaN to integer
[WARN] [1773494158.685387750] [rqt_reconfigure]: Failed to retrieve parameters from node: cannot convert float NaN to integer
```

This PR fixes the behavior. 

tbh: The slider does not make a lot of sense with a max value of 1e308, but at least the GUI still works.