### PR TITLE
Fix missing parameters for nodes where one or more parameters can't be read

### DIFF
--- a/src/rqt_reconfigure/param_api.py
+++ b/src/rqt_reconfigure/param_api.py
@@ -35,8 +35,23 @@ from rcl_interfaces.srv import GetParameters
 from rcl_interfaces.srv import ListParameters
 from rcl_interfaces.srv import SetParameters
 
+from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_parameter_events
+
+from rqt_reconfigure import logging
+
+# How long to wait for the remote node's parameter services to show up in the
+# ROS graph. Only paid when the node is not up (yet) at all.
+_DISCOVERY_TIMEOUT = 5.0
+# Timeout for a single attempt at an individual service call. A healthy,
+# spinning node answers well within this window.
+_CALL_TIMEOUT = 1.0
+# Number of attempts per service call. Retrying works around the race where
+# service_is_ready() already reports True from the ROS graph cache while the
+# DDS request writer has not finished matching the server's request reader,
+# which silently drops the request.
+_CALL_ATTEMPTS = 3
 
 
 class AsyncServiceCallFailed(Exception):
@@ -52,33 +67,65 @@ class ParamClient(object):
 
         self._node = node
         self._remote_node_name = remote_node_name
+        # Keep these entities out of the node's default callback group. That
+        # group is a MutuallyExclusiveCallbackGroup shared by every rqt plugin
+        # loaded in this process and by every other node panel opened here.
+        # While any entity in it executes, the executor's wait set excludes all
+        # the others (rclpy Executor._wait_for_ready_callbacks() filters on
+        # can_execute()), so our service responses would be delayed past the
+        # timeout in _call_service() below.
+        #
+        # Reentrancy is safe here: _on_parameter_event() only reads
+        # _remote_node_name and builds local lists, and the clients' response
+        # callbacks only fulfil their own future. Reconsider if this class ever
+        # gains mutable state shared between callbacks.
+        self._callback_group = ReentrantCallbackGroup()
         self._get_params_client = self._node.create_client(
-            GetParameters, '{remote_node_name}/get_parameters'.format_map(locals())
+            GetParameters, '{remote_node_name}/get_parameters'.format_map(locals()),
+            callback_group=self._callback_group
         )
         self._set_params_client = self._node.create_client(
-            SetParameters, '{remote_node_name}/set_parameters'.format_map(locals())
+            SetParameters, '{remote_node_name}/set_parameters'.format_map(locals()),
+            callback_group=self._callback_group
         )
         self._list_params_client = self._node.create_client(
-            ListParameters, '{remote_node_name}/list_parameters'.format_map(locals())
+            ListParameters, '{remote_node_name}/list_parameters'.format_map(locals()),
+            callback_group=self._callback_group
         )
         self._describe_params_client = self._node.create_client(
-            DescribeParameters, '{remote_node_name}/describe_parameters'.format_map(locals())
+            DescribeParameters, '{remote_node_name}/describe_parameters'.format_map(locals()),
+            callback_group=self._callback_group
         )
         self._param_events_subscription = self._node.create_subscription(
             ParameterEvent, '/parameter_events', self._on_parameter_event,
-            qos_profile_parameter_events
+            qos_profile_parameter_events, callback_group=self._callback_group
         )
         self._param_change_callback = param_change_callback
+        # Parameters this node advertises but will not return a value for, so
+        # that get_parameters() reports each of them only once.
+        self._unreadable_params = set()
 
     def _on_parameter_event(self, event):
         if event.node != self._remote_node_name:
             return
         if self._param_change_callback is not None:
-            self._param_change_callback(
-                [Parameter.from_parameter_msg(p) for p in event.new_parameters],
-                [Parameter.from_parameter_msg(p) for p in event.changed_parameters],
-                [Parameter.from_parameter_msg(p) for p in event.deleted_parameters]
-            )
+            try:
+                self._param_change_callback(
+                    [Parameter.from_parameter_msg(p) for p in event.new_parameters],
+                    [Parameter.from_parameter_msg(p) for p in event.changed_parameters],
+                    [Parameter.from_parameter_msg(p) for p in event.deleted_parameters]
+                )
+            except Exception as e:
+                # This runs on the executor thread of the node shared by all rqt
+                # plugins. rqt_gui_py's RclpySpinner does not guard its spin
+                # loop, and MultiThreadedExecutor re-raises task exceptions
+                # there, so anything escaping this callback would stop that node
+                # from spinning for every plugin for the rest of the process.
+                # See ros-visualization/rqt_reconfigure#146.
+                logging.warn(
+                    'Failed to handle parameter event for node'
+                    ' {}: {}'.format(self._remote_node_name, e)
+                )
 
     def list_parameters(self):
         list_params_request = ListParameters.Request()
@@ -86,13 +133,61 @@ class ParamClient(object):
         return list_params_response.result.names
 
     def get_parameters(self, names):
-        get_params_request = GetParameters.Request()
-        get_params_request.names = names
-        get_params_response = self._call_service(self._get_params_client, get_params_request)
+        """
+        Read the given parameters, skipping the ones the node refuses to serve.
+
+        The returned list may be shorter than ``names``, so callers must not
+        assume it lines up positionally with anything derived from ``names``.
+        """
+        if not names:
+            return []
+
+        pairs = self._get_parameters_partial(list(names))
+
+        unreadable = [name for name in names if name not in {n for n, _ in pairs}]
+        # Only report each parameter once: this runs again on every keystroke in
+        # the parameter filter box.
+        new_unreadable = [n for n in unreadable if n not in self._unreadable_params]
+        if new_unreadable:
+            self._unreadable_params.update(new_unreadable)
+            logging.warn(
+                'Node {} did not return a value for {} parameter(s), which are most'
+                ' likely declared without being initialized: {}'.format(
+                    self._remote_node_name, len(new_unreadable), ', '.join(new_unreadable)
+                )
+            )
+
         return [
             Parameter.from_parameter_msg(ParameterMsg(name=name, value=value))
-            for name, value in zip(names, get_params_response.values)
+            for name, value in pairs
         ]
+
+    def _get_parameters_partial(self, names):
+        """
+        Return the (name, value) pairs that could be read, as a list.
+
+        rclcpp's GetParameters handler is all or nothing: if any requested
+        parameter was declared without being initialized, it logs a warning and
+        answers with an empty value list instead of a partial one. A single such
+        parameter would therefore hide every parameter of the node. Bisect the
+        request so that only the offending parameters are dropped, which costs
+        far fewer round trips than asking for every parameter separately.
+
+        A request that times out still raises, so an unresponsive node fails
+        fast instead of being retried once per parameter.
+        """
+        get_params_request = GetParameters.Request()
+        get_params_request.names = names
+        values = self._call_service(self._get_params_client, get_params_request).values
+
+        if len(values) == len(names):
+            return list(zip(names, values))
+        if len(names) == 1:
+            return []
+
+        middle = len(names) // 2
+        return (self._get_parameters_partial(names[:middle]) +
+                self._get_parameters_partial(names[middle:]))
 
     def describe_parameters(self, names):
         describe_params_request = DescribeParameters.Request()
@@ -104,7 +199,12 @@ class ParamClient(object):
     def set_parameters(self, parameters):
         set_params_request = SetParameters.Request()
         set_params_request.parameters = [p.to_parameter_msg() for p in parameters]
-        return self._call_service(self._set_params_client, set_params_request)
+        # Unlike the read-only calls above this one is not guaranteed to be
+        # idempotent, because the remote node's on-set-parameters callback may
+        # have side effects. Allow a single retry, which is enough to survive the
+        # matching race described at _CALL_ATTEMPTS on this service's own
+        # request writer, while bounding the risk of applying a change twice.
+        return self._call_service(self._set_params_client, set_params_request, attempts=2)
 
     def close(self):
         self._node.destroy_subscription(self._param_events_subscription)
@@ -113,24 +213,33 @@ class ParamClient(object):
         self._node.destroy_client(self._set_params_client)
         self._node.destroy_client(self._get_params_client)
 
-    def _call_service(self, client, request, timeout=1.0):
+    def _call_service(self, client, request, timeout=_CALL_TIMEOUT, attempts=_CALL_ATTEMPTS):
         if not client.service_is_ready():
-            if not client.wait_for_service(timeout):
+            if not client.wait_for_service(_DISCOVERY_TIMEOUT):
                 raise AsyncServiceCallFailed(hint='timed out waiting for service')
 
         # It is possible that a node has the parameter services but is not
-        # spinning. In that is the case, the client call will time out.
-        event = Event()
-        future = client.call_async(request)
-        future.add_done_callback(lambda _: event.set())
+        # spinning. In that is the case, every attempt below times out. It is
+        # also possible that only the first attempt is lost because the request
+        # writer had not finished matching yet, hence the retries.
+        for _attempt in range(attempts):
+            event = Event()
+            future = client.call_async(request)
+            # Bind the event explicitly so a done callback left over from an
+            # earlier attempt can never signal a later attempt's event.
+            future.add_done_callback(lambda _, event=event: event.set())
 
-        event.wait(timeout)
+            # future.done() covers the response landing in the race between the
+            # wait above expiring and this check.
+            if event.wait(timeout) or future.done():
+                return future.result()
 
-        result = future.result()
-        if result is None:
-            raise AsyncServiceCallFailed(hint='the target node may not be spinning')
+            # Abandon this attempt's request so it does not stay in the client's
+            # pending requests forever. cancel() synchronously invokes the
+            # remove_pending_request done callback registered by call_async().
+            future.cancel()
 
-        return future.result()
+        raise AsyncServiceCallFailed(hint='the target node may not be spinning')
 
 
 def create_param_client(node, remote_node_name, param_change_callback=None):

--- a/src/rqt_reconfigure/param_client_widget.py
+++ b/src/rqt_reconfigure/param_client_widget.py
@@ -64,6 +64,8 @@ class ParamClientWidget(QWidget):
 
     sig_node_disabled_selected = Signal(str)
     sig_node_state_change = Signal(bool)
+    # Carries (new_parameters, changed_parameters, deleted_parameters).
+    sig_param_event = Signal(object, object, object)
 
     def __init__(self, context, node_name):
         """
@@ -77,8 +79,16 @@ class ParamClientWidget(QWidget):
 
         self._editor_widgets = {}
 
+        # Parameter events arrive on the executor thread of the node shared by
+        # all rqt plugins. Route them through a signal so _handle_param_event()
+        # runs on the GUI thread instead: this widget was created there, so Qt
+        # turns the cross-thread emission into a queued connection. That keeps
+        # both the widget manipulation and the blocking describe_parameters()
+        # call out of the executor thread, where they would otherwise corrupt Qt
+        # state and stall every other callback on the shared node.
+        self.sig_param_event.connect(self._handle_param_event)
         self._param_client = create_param_client(
-            context.node, node_name, self._handle_param_event
+            context.node, node_name, self.sig_param_event.emit
         )
 
         verticalLayout = QVBoxLayout(self)
@@ -125,9 +135,13 @@ class ParamClientWidget(QWidget):
         # Again, these UI operation above needs to happen in .ui file.
         try:
             param_names = self._param_client.list_parameters()
+            # Describe only the parameters that could actually be read:
+            # get_parameters() drops the ones the node refuses to serve, and
+            # add_editor_widgets() pairs the two lists positionally.
+            parameters = self._param_client.get_parameters(param_names)
             self.add_editor_widgets(
-                self._param_client.get_parameters(param_names),
-                self._param_client.describe_parameters(param_names)
+                parameters,
+                self._param_client.describe_parameters([p.name for p in parameters])
             )
         except Exception as e:
             logging.warn(
@@ -162,7 +176,6 @@ class ParamClientWidget(QWidget):
     def _handle_param_event(
         self, new_parameters, changed_parameters, deleted_parameters
     ):
-        # TODO: Think about replacing callback architecture with signals.
         if new_parameters:
             try:
                 new_descriptors = self._param_client.describe_parameters(
@@ -224,14 +237,16 @@ class ParamClientWidget(QWidget):
         pass
 
     def remove_editor_widgets(self, parameters):
-        for parameter in parameters:
-            if parameter.name not in self._editor_widgets:
+        self.remove_editor_widgets_by_name([p.name for p in parameters])
+
+    def remove_editor_widgets_by_name(self, names):
+        for name in names:
+            if name not in self._editor_widgets:
                 continue
-            logging.debug('Removing editor widget for {}'.format(
-                parameter.name))
-            self._editor_widgets[parameter.name].hide(self.grid)
-            self._editor_widgets[parameter.name].close()
-            del self._editor_widgets[parameter.name]
+            logging.debug('Removing editor widget for {}'.format(name))
+            self._editor_widgets[name].hide(self.grid)
+            self._editor_widgets[name].close()
+            del self._editor_widgets[name]
 
     def update_editor_widgets(self, parameters):
         for parameter in parameters:
@@ -263,6 +278,14 @@ class ParamClientWidget(QWidget):
         self.sig_node_disabled_selected.emit(self._toplevel_treenode_name)
 
     def close(self):
+        # Drop the connection first: an event emitted from the executor thread
+        # may already be queued, and it must not reach the editor widgets that
+        # are torn down below.
+        try:
+            self.sig_param_event.disconnect(self._handle_param_event)
+        except (RuntimeError, TypeError):
+            pass
+
         self._param_client.close()
 
         for w in self._editor_widgets.values():
@@ -278,14 +301,15 @@ class ParamClientWidget(QWidget):
             param_names = self._param_client.list_parameters()
             param_names_filtered = \
                 list(filter(lambda p: filter_key in p, param_names)) if filter_key else param_names
-            client_params_remove = self._param_client.get_parameters(
-                list(self._editor_widgets.keys()))
-            self.remove_editor_widgets(client_params_remove)
+            # Remove by name rather than reading the values back first: the
+            # values are unused here, and parameters the node refuses to serve
+            # would otherwise keep their editor widget and then be added again.
+            self.remove_editor_widgets_by_name(list(self._editor_widgets.keys()))
             client_params_filtered = self._param_client.get_parameters(
                 param_names_filtered
             )
             client_params_desc = self._param_client.describe_parameters(
-                param_names_filtered
+                [p.name for p in client_params_filtered]
             )
             self.add_editor_widgets(
                 client_params_filtered,

--- a/src/rqt_reconfigure/param_editors.py
+++ b/src/rqt_reconfigure/param_editors.py
@@ -83,8 +83,9 @@ class EditorWidget(QWidget):
         Update the value that's displayed on the arbitrary GUI component
         based on user's input.
 
-        This method is not called from the GUI thread, so any changes to
-        QObjects will need to be done through a signal.
+        This method is called from the GUI thread: parameter events coming from
+        the executor thread are marshalled onto it by
+        ParamClientWidget.sig_param_event before this is reached.
         """
         self.parameter = Parameter(
             name=self.parameter.name,

--- a/src/rqt_reconfigure/paramedit_widget.py
+++ b/src/rqt_reconfigure/paramedit_widget.py
@@ -106,7 +106,7 @@ class ParameditWidget(QWidget):
              self.palette().window().color().darker(125)])
 
     def close(self):
-        for w in self._param_client_widgets:
+        for w in self._param_client_widgets.values():
             w.close()
         self._param_client_widgets.clear()
         self._paramedit_scrollarea.deleteLater()


### PR DESCRIPTION
The empty parameter panel reported in #146 is not a single bug. Debugging it turned up four
independent problems, each of which is enough on its own to hide every parameter of a node.
This PR fixes all of them.

## 1. `get_parameters` is all or nothing

`rclcpp`'s `GetParameters` handler answers with an *empty* value list (and a warning on the node
side) as soon as **one** of the requested parameters was declared without being initialized.
`rqt_reconfigure` asks for all parameters of a node in a single request, so
`zip(names, response.values)` then yields nothing and the panel comes up empty even though
`list_parameters` returned the full list — exactly the discrepancy shown in the issue.

`ParamClient._get_parameters_partial()` now bisects the request, so only the parameters the node
actually refuses to serve are dropped, at far fewer round trips than one request per parameter.
Each dropped parameter is reported once per node, with a hint about the likely cause.

Because the result may now be shorter than the requested names, `get_parameters()` returns
`(name, value)` pairs internally and every caller that used to pair the two lists positionally
was updated to describe only the parameters that were really read.

## 2. Parameter service clients shared the node's default callback group

The four parameter clients and the `/parameter_events` subscription were created in the default
callback group of `context.node`. That group is a `MutuallyExclusiveCallbackGroup` shared by
every rqt plugin in the process and by every node panel opened in this one. While any entity in
it executes, rclpy's executor drops all the others from its wait set, so a service response could
not be delivered within the 1 s call timeout and the call failed with
`the target node may not be spinning` — even against a perfectly healthy node.

They now live in a dedicated `ReentrantCallbackGroup`. The reentrancy is safe here (the event
callback only reads the remote node name, the response callbacks only fulfil their own future)
and this is noted in the code in case the class gains shared mutable state later.

## 3. Parameter events were handled on the executor thread

`_handle_param_event()` manipulated Qt widgets and made blocking `describe_parameters()` calls
directly from the executor thread. Two consequences:

* Blocking there stalls the node shared by all plugins (and, before fix 2, blocked the very
  response it was waiting for).
* Anything raised in that callback escapes `MultiThreadedExecutor` into `RclpySpinner`'s
  unguarded spin loop and stops the shared node from spinning **for every plugin, for the rest of
  the process**. That is the second reproduction path in #146: after closing one node's editor,
  no parameters are shown for any node.

Events are now emitted as a Qt signal, so `_handle_param_event()` runs on the GUI thread through
a queued connection; the connection is dropped first in `close()` so a queued event cannot reach
torn-down editor widgets, and the callback itself is guarded and logs instead of killing the
executor. The now-stale threading note on `EditorWidget.update_local()` and the
`TODO: Think about replacing callback architecture with signals` were updated/removed accordingly.

## 4. Lost first request and a too-short discovery timeout

`service_is_ready()` can already report `True` from the ROS graph cache while the DDS request
writer has not finished matching the server's request reader, in which case the first request is
silently dropped and the call times out. `wait_for_service()` also reused the 1 s call timeout,
which is short for a node that is only just coming up.

`_call_service()` now separates discovery (5 s) from the per-attempt call timeout (1 s) and
retries. Read-only calls get 3 attempts; `set_parameters` gets 2, since the remote
on-set-parameters callback may have side effects and must not be replayed more than necessary.
Abandoned futures are cancelled so they do not pile up in the client's pending requests, each
attempt's done callback is bound to its own event, and `future.done()` is checked to cover a
response landing just as the wait expires.

## Drive-by fixes in the same paths

* `ParamEditWidget.close()` iterated `self._param_client_widgets` instead of its `.values()`, so
  it called `close()` on a `str` key and raised.
* `_filter_param()` read parameter values back only to derive the names of the widgets to remove.
  Parameters the node refuses to serve therefore kept their widget and were added a second time;
  removal is now by name.

## Notes

* No new dependencies, no user-facing API change.
* Targets `jazzy`; the same problems exist on `rolling` and `humble`, so this is worth
  forward-/backporting.
* Tested manually against nodes with uninitialized declared parameters, nodes started before and
  after rqt, and repeated open/close cycles of several node panels in one rqt session.
